### PR TITLE
Disclosure widget for large text columns

### DIFF
--- a/lib/GADS/Role/Presentation/Record.pm
+++ b/lib/GADS/Role/Presentation/Record.pm
@@ -10,6 +10,7 @@ sub _presentation_map_columns {
             is_multivalue => $_->multivalue,
             type          => $_->type,
             data          => $self->fields->{$_->id}->presentation,
+            name          => $_->name
         }
     } @columns;
 

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1335,4 +1335,6 @@ small.search_term {
   padding: .5em;
   margin-top: .5em;
   width: 80%;
-  word-break: break-word; }
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: initial; }

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1243,19 +1243,21 @@ small.search_term {
 .trigger[aria-expanded="true"] + .expandable {
   display: block; }
 
-/* Person contact details popover */
-.person.contact-details.expandable {
-  max-width: 25em;
+.expandable {
   word-break: break-all;
   border: 1px solid #1460aa;
   border-radius: 6px;
   -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   background-color: #fff;
-  padding: .5em;
-  margin: .5em;
   z-index: 5;
   position: absolute; }
+
+/* Person contact details popover */
+.person.contact-details {
+  max-width: 25em;
+  padding: .5em;
+  margin: .5em; }
 
 /* RAG legend */
 #rag_legend {
@@ -1311,12 +1313,26 @@ small.search_term {
   background-color: rgba(137, 30, 136, 0.3); }
 
 /* Data table */
-.table th * {
+#data-table th * {
   color: #000; }
 
-.table thead button {
+#data-table thead button {
   border: 1px solid #bbb;
   background-color: inherit;
   vertical-align: bottom;
   margin-left: 0.2em;
   margin-bottom: 0.2em; }
+
+/* less / more */
+.more-less.clipped {
+  height: 60px;
+  overflow: hidden; }
+
+.more-less.transparent {
+  color: transparent; }
+
+.more-less .column-content {
+  padding: .5em;
+  margin-top: .5em;
+  width: 80%;
+  word-break: break-word; }

--- a/public/js/linkspace.js
+++ b/public/js/linkspace.js
@@ -1,3 +1,49 @@
+var setupLessMoreWidgets = function () {
+    var MAX_HEIGHT = 100;
+
+    var convert = function () {
+        var $ml = $(this);
+        var column = $ml.data('column');
+        var content = $ml.html();
+
+        $ml.removeClass('transparent');
+
+        if ($ml.height() < MAX_HEIGHT) {
+            return;
+        }
+
+        $ml.addClass('clipped');
+
+        var $expandable = $('<div/>', {
+            'class' : 'expandable column-content',
+            'html'  : content
+        });
+
+        var toggleLabel = 'Show ' + column + ' &rarr;';
+
+        var $expandToggle = $('<button/>', {
+            'class' : 'btn btn-xs btn-primary trigger',
+            'html'  : toggleLabel,
+            'aria-expanded' : false,
+            'data-label-expanded' : 'Hide ' + column,
+            'data-label-collapsed' : toggleLabel
+        });
+
+        $expandToggle.on('toggle', function (e, state) {
+            if (state === 'expanded') {
+                $expandable.css('width', $ml.width() + 'px');
+            }
+        });
+
+        $ml.empty()
+           .append($expandToggle)
+           .append($expandable);
+    };
+
+    var $widgets = $('.more-less');
+    $widgets.each(convert);
+};
+
 var setupDisclosureWidgets = function () {
     var positionDisclosure = function (offsetTop, offsetLeft, triggerHeight) {
         var $disclosure = this;
@@ -13,7 +59,7 @@ var setupDisclosureWidgets = function () {
 
     var toggleDisclosure = function () {
         var $trigger = $(this);
-        var $disclosure = $trigger.next('.expandable');
+        var $disclosure = $trigger.siblings('.expandable').first();
 
         var offset = $trigger.position();
         positionDisclosure.call(
@@ -22,6 +68,15 @@ var setupDisclosureWidgets = function () {
 
         var currentlyExpanded = $trigger.attr('aria-expanded') === 'true';
         $trigger.attr('aria-expanded', !currentlyExpanded);
+
+        var expandedLabel = $trigger.data('label-expanded');
+        var collapsedLabel = $trigger.data('label-collapsed');
+
+        if (collapsedLabel.length && expandedLabel.length) {
+            $trigger.html(currentlyExpanded ? collapsedLabel : expandedLabel);
+        }
+
+        $trigger.trigger('toggle', currentlyExpanded ? 'collapsed' : 'expanded');
     };
 
     $('.trigger[aria-expanded]').on('click', toggleDisclosure);
@@ -29,6 +84,7 @@ var setupDisclosureWidgets = function () {
 
 var Linkspace = {
     init: function () {
+        setupLessMoreWidgets();
         setupDisclosureWidgets();
     }
 };

--- a/public/js/linkspace.js
+++ b/public/js/linkspace.js
@@ -30,8 +30,18 @@ var setupLessMoreWidgets = function () {
         });
 
         $expandToggle.on('toggle', function (e, state) {
+            var windowWidth = $(window).width();
+            var leftOffset = $expandable.offset().left;
+            var minWidth = 400;
+            var colWidth = $ml.width();
+            var newWidth = colWidth > minWidth ? colWidth : minWidth;
             if (state === 'expanded') {
-                $expandable.css('width', $ml.width() + 'px');
+                $expandable.css('width', newWidth + 'px');
+                if (leftOffset + newWidth + 20 < windowWidth) {
+                    return;
+                }
+                var overflow = windowWidth - (leftOffset + newWidth + 20);
+                $expandable.css('left', (leftOffset + overflow) + 'px');
             }
         });
 

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1366,21 +1366,23 @@ small.search_term {
     display: block; 
 }
 
-
-/* Person contact details popover */
-
-.person.contact-details.expandable {
-    max-width: 25em;
+.expandable {
     word-break: break-all;
     border: 1px solid $primary-navy;
     border-radius: 6px;
     -webkit-box-shadow: 0 5px 10px rgba(0,0,0,.2);
     box-shadow: 0 5px 10px rgba(0,0,0,.2);
     background-color: #fff;
-    padding: .5em;
-    margin: .5em;
     z-index: 5;
     position: absolute;
+}
+
+/* Person contact details popover */
+
+.person.contact-details {
+    max-width: 25em;
+    padding: .5em;
+    margin: .5em;
 }
 
 /* RAG legend */
@@ -1448,17 +1450,36 @@ small.search_term {
 .rag .unexpected {
     border-bottom-color: $rag-unexpected;
     background-color: $rag-unexpected-bg;
+}
 
 /* Data table */
 
-.table th * {
+#data-table th * {
     color: #000;
 }
 
-.table thead button {
+#data-table thead button {
     border: 1px solid #bbb;
     background-color: inherit;
     vertical-align: bottom;
     margin-left: 0.2em;
     margin-bottom: 0.2em;
+}
+
+/* less / more */
+
+.more-less.clipped {
+    height: 60px;
+    overflow: hidden;
+}
+
+.more-less.transparent {
+    color: transparent;
+}
+
+.more-less .column-content {
+    padding: .5em;
+    margin-top: .5em;
+    width: 80%;
+    word-break: break-word;
 }

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1481,5 +1481,7 @@ small.search_term {
     padding: .5em;
     margin-top: .5em;
     width: 80%;
-    word-break: break-word;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    word-break: initial;
 }

--- a/views/data_table.tt
+++ b/views/data_table.tt
@@ -92,9 +92,7 @@
                 [% END %]
             </td>
             [% FOREACH column IN record.columns %]
-                [% column_index = loop.index %]
-                [% col_header = columns.${column_index} %]
-                <td class="[% column.type %]">[% render_datum(column, col_header.name) %]</td>
+                <td class="[% column.type %]">[% render_datum(column) %]</td>
             [% END %]
         </tr>
         [% END %]

--- a/views/data_table.tt
+++ b/views/data_table.tt
@@ -34,7 +34,7 @@
     [% END %]
 [% END %]
 <div class="hscroll">
-<table class="table table-striped" id="datatable">
+<table class="table table-striped" id="data-table">
     <thead>
         <tr>
             [% sort = sort.shift %]
@@ -92,7 +92,9 @@
                 [% END %]
             </td>
             [% FOREACH column IN record.columns %]
-                <td class="[% column.type %]">[% render_datum(column) %]</td>
+                [% column_index = loop.index %]
+                [% col_header = columns.${column_index} %]
+                <td class="[% column.type %]">[% render_datum(column, col_header.name) %]</td>
             [% END %]
         </tr>
         [% END %]
@@ -167,31 +169,6 @@
                 $("#datatable").floatThead({
                     zIndex: function($table){
                         return 999;
-                    }
-                });
-                var adjustheight = 60;
-                var moreText = '+ More';
-                var lessText = '- Less';
-                var items = $('.more-less .more-block');
-                var $currentItem;
-                for (var i = 0, j = items.length; i < j; i++) {
-                    $currentItem = $(items[i]);
-
-                    if ($currentItem.height() > adjustheight){
-                        $currentItem.css('height', adjustheight).css('overflow', 'hidden');
-                        $currentItem.parent(".more-less").append
-                            ('<a style="cursor:pointer" class="adjust">' + moreText + '</a>');
-                    }
-                };
-                $(".adjust").click(function() {
-                    if ($(this).prev().css('overflow') == 'hidden')
-                    {
-                        $(this).prev().css('height', 'auto').css('overflow', 'visible');
-                        $(this).text(lessText);
-                    }
-                    else {
-                        $(this).prev().css('height', adjustheight).css('overflow', 'hidden');
-                        $(this).text(moreText);
                     }
                 });
                 if (!FontDetect.isFontLoaded('14px/1 FontAwesome')) {

--- a/views/snippets/datum.tt
+++ b/views/snippets/datum.tt
@@ -48,7 +48,7 @@
     </div>
 [% END %]
 
-[% MACRO render_string_datum(string) BLOCK %]
+[% MACRO render_string_datum(string, header) BLOCK %]
     [% IF string.html.defined && string.html.length > MORE_LESS_TRESHOLD %]
         [% WRAPPER more_less_block %]
             [% string.html %]
@@ -63,16 +63,16 @@
     <span aria-labelledby="rag_[% grade %]_meaning" class="[% grade %]">[% rag_symbols.$grade %]</span>
 [% END %]
 
-[% MACRO render_datum(datum, header) BLOCK;
+[% MACRO render_datum(datum) BLOCK;
     SWITCH datum.type;
         CASE 'curval'; 
-            render_curval_datum(datum.is_multivalue, datum.data, header);
+            render_curval_datum(datum.is_multivalue, datum.data, datum.name);
         CASE 'file';
             render_file_datum(datum.data);
         CASE 'person';
             render_person_datum(datum.data);
         CASE 'string';
-            render_string_datum(datum.data, header);
+            render_string_datum(datum.data, datum.name);
         CASE 'rag';
             render_rag_datum(datum.data);
         CASE;

--- a/views/snippets/datum.tt
+++ b/views/snippets/datum.tt
@@ -1,14 +1,12 @@
 [% MORE_LESS_TRESHOLD = 50 %]
 
 [% BLOCK more_less_block %]
-    <div class="more-less">
-        <div class="more-block">
+    <div class="more-less" data-column="[% header | html %]">
         [% content %]
-        </div>
     </div>
 [% END %]
 
-[% MACRO render_curval_datum(is_multivalue, curval) BLOCK %]
+[% MACRO render_curval_datum(is_multivalue, curval, header) BLOCK %]
     [% IF curval.text.length > MORE_LESS_TRESHOLD %]
         [% WRAPPER more_less_block %]
             [% IF is_multivalue %]
@@ -65,16 +63,16 @@
     <span aria-labelledby="rag_[% grade %]_meaning" class="[% grade %]">[% rag_symbols.$grade %]</span>
 [% END %]
 
-[% MACRO render_datum(datum) BLOCK;
+[% MACRO render_datum(datum, header) BLOCK;
     SWITCH datum.type;
         CASE 'curval'; 
-            render_curval_datum(datum.is_multivalue, datum.data);
+            render_curval_datum(datum.is_multivalue, datum.data, header);
         CASE 'file';
             render_file_datum(datum.data);
         CASE 'person';
             render_person_datum(datum.data);
         CASE 'string';
-            render_string_datum(datum.data);
+            render_string_datum(datum.data, header);
         CASE 'rag';
             render_rag_datum(datum.data);
         CASE;


### PR DESCRIPTION
This deals with the fact that any table can have `n` columns that we have no control over. Any column can contain text depending on its type, and this text can be very large. It may also contain links.

I ended up going for a disclosure widget, in which the column header name is added to provide proper context. The column content is disclosed in familiar style, with a minimum width. If the width exceeds the viewport, it gets adjusted in its position.

This is still a hack to patch a deeper problem; having columns with lots of PRs, or columns with large amounts of text are a UX anti pattern. Ideally GADS administrators should be aware of how to effectively compose tables.

Any of the other potential solutions ("detail views", "card view", "list of cards", "rotate the table") come with other issues. The main obstacle remains the need for an entire flexible and undefined table configuration system, of which the results remain cognitively accessible.

In the end, reducing cognitive load will be the responsibility of the table designer. We can only do so much without having knowledge of the actual data and user goals.