### PR TITLE
Manage fields accessibility

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,6 +34,7 @@ WriteMakefile(
         'DBIx::Class::Migration'                    => 0,
         'DBIx::Class::ResultClass::HashRefInflator' => 0,
         'HTML::FromText'                            => 0,
+        'List::Compare'                             => 0,
         'Log::Report'                               => 1.16,
         'Mail::Message'                             => 0,
         'Math::Round'                               => 0,

--- a/lib/GADS.pm
+++ b/lib/GADS.pm
@@ -1310,45 +1310,6 @@ any '/layout/?:id?' => require_role 'layout' => sub {
                 layout => $layout
             );
         
-        # Update of permissions?
-        if (param 'modal_access_control')
-        {
-            my $groups         = [body_parameters->get_all('group_id')];
-            my $read           = [body_parameters->get_all('read')];
-            my $write_new      = [body_parameters->get_all('write_new')];
-            my $write_existing = [body_parameters->get_all('write_existing')];
-            if (process sub { $column->set_permissions(
-                groups         => $groups,
-                read           => $read,
-                write_new      => $write_new,
-                write_existing => $write_existing
-            ) })
-            {
-                my $msg = qq(Permissions have been updated successfully. <a href="/layout/">Click here</a> to return to Edit Layout.);
-                report NOTICE => $msg, _class => 'html,success';
-                return forwardHome( undef, "layout/".$column->id );
-            }
-        }
-        if (param 'modal_approval_control')
-        {
-            my $groups                     = [body_parameters->get_all('group_id')];
-            my $approve_new                = [body_parameters->get_all('approve_new')];
-            my $approve_existing           = [body_parameters->get_all('approve_existing')];
-            my $write_new_no_approval      = [body_parameters->get_all('write_new_no_approval')];
-            my $write_existing_no_approval = [body_parameters->get_all('write_existing_no_approval')];
-            if (process sub { $column->set_permissions(
-                groups                     => $groups,
-                approve_new                => $approve_new,
-                approve_existing           => $approve_existing,
-                write_new_no_approval      => $write_new_no_approval,
-                write_existing_no_approval => $write_existing_no_approval,
-            ) })
-            {
-                my $msg = qq(Permissions have been updated successfully. <a href="/layout/">Click here</a> to return to Edit Layout.);
-                report NOTICE => $msg, _class => 'html,success';
-                return forwardHome( undef, "layout/".$column->id );
-            }
-        }
 
         if (param 'delete')
         {
@@ -1367,6 +1328,20 @@ any '/layout/?:id?' => require_role 'layout' => sub {
 
         if (param 'submit')
         {
+
+            my @permission_params = grep { /^permission_(?:.*?)_\d+$/ } keys %{ params };
+
+            if (@permission_params) {
+                my %permissions;
+
+                foreach my $p (@permission_params) {
+                    my ($name, $group_id) = m/^permission_(.*?)_(\d+)$/;
+                    push ($permissions{$group_id} ||= []), $name;
+                }
+                
+                $column->set_permissions(%permissions);
+            }
+
             $column->$_(param $_)
                 foreach (qw/name name_short description helptext optional isunique multivalue remember link_parent_id/);
             $column->type(param 'type')

--- a/lib/GADS/Column.pm
+++ b/lib/GADS/Column.pm
@@ -32,6 +32,8 @@ use GADS::View;
 use Moo;
 use MooX::Types::MooseLike::Base qw/:all/;
 
+use List::Compare ();
+
 use namespace::clean; # Otherwise Enum clashes with MooseLike
 
 with 'GADS::Role::Presentation::Column';
@@ -909,99 +911,20 @@ sub user_id_can
     grep { $_ eq $permission } @$perms;
 }
 
-sub set_permissions
-{   my ($self, %options) = @_;
+sub set_permissions {
+    my ($self, %permissions) = @_;
 
-
-    # These set from web form
-    my $groups                     = $options{groups};
-    my $read                       = $options{read};
-    my $write_new                  = $options{write_new};
-    my $write_existing             = $options{write_existing};
-    my $approve_new                = $options{approve_new};
-    my $approve_existing           = $options{approve_existing};
-    my $write_new_no_approval      = $options{write_new_no_approval};
-    my $write_existing_no_approval = $options{write_existing_no_approval};
-
-    # This for setting permissions directly
-    my $permissions = $options{permissions};
-    my $type;
-
-    if ($permissions)
-    {
-        $type = 'all';
-        $groups = [ keys %$permissions ];
-    }
-    elsif (exists $options{read} && exists $options{write_new} && exists $options{write_existing})
-    {
-        $type = 'access';
-        foreach my $group_id (@$groups)
-        {
-            my @perms;
-
-            # For each permission type, see if it is set (a value that is not the
-            # next hidden placeholder value). If it is, shift the actual value, to
-            # make sure that the next value is the next placeholder
-
-            shift @$read eq 'holder' or panic "Missing holder for read";
-            push @perms, 'read'
-                if $read->[0] && $read->[0] ne 'holder' && shift @$read;
-
-            shift @$write_new eq 'holder' or panic "Missing holder for write_new";
-            push @perms, 'write_new'
-                if $write_new->[0] && $write_new->[0] ne 'holder' && shift @$write_new;
-
-            shift @$write_existing eq 'holder' or panic "Missing holder for write_existing";
-            push @perms, 'write_existing'
-                if $write_existing->[0] && $write_existing->[0] ne 'holder' && shift @$write_existing;
-
-            $permissions->{$group_id} = [@perms]
-                if $group_id; # May not have been group selected in drop-down
-        }
-    }
-    elsif (exists $options{approve_new} && exists $options{approve_existing}
-        && exists $options{write_new_no_approval} && exists $options{write_existing_no_approval})
-    {
-        $type = 'approval';
-        foreach my $group_id (@$groups)
-        {
-            my @perms;
-
-            # As above
-
-            shift @$approve_new eq 'holder' or panic "Missing holder for approve_new";
-            push @perms, 'approve_new'
-                if $approve_new->[0] && $approve_new->[0] ne 'holder' && shift @$approve_new;
-
-            shift @$approve_existing eq 'holder' or panic "Missing holder for approve_existing";
-            push @perms, 'approve_existing'
-                if $approve_existing->[0] && $approve_existing->[0] ne 'holder' && shift @$approve_existing;
-
-            shift @$write_new_no_approval eq 'holder' or panic "Missing holder for write_new_no_approval";
-            push @perms, 'write_new_no_approval'
-                if $write_new_no_approval->[0] && $write_new_no_approval->[0] ne 'holder' && shift @$write_new_no_approval;
-
-            shift @$write_existing_no_approval eq 'holder' or panic "Missing holder for write_existing_no_approval";
-            push @perms, 'write_existing_no_approval'
-                if $write_existing_no_approval->[0] && $write_existing_no_approval->[0] ne 'holder' && shift @$write_existing_no_approval;
-
-            $permissions->{$group_id} = [@perms]
-                if $group_id; # May not have been group selected in drop-down
-        }
-    }
-    else {
-        panic "Invalid call of set_permissions";
-    }
-
-    $groups = [ grep {$_} @$groups ]; # Remove permissions with blank submitted group
+    my @groups = keys %permissions;
 
     # Search for any groups that were in the permissions but no longer exist
     my $search = {
         layout_id => $self->id,
     };
-    $search->{group_id} = { '!=' => [ '-and', @$groups ] }
-        if @$groups;
-    push @$groups, $self->schema->resultset('LayoutGroup')->search($search,{
+
+    $search->{group_id} = { '!=' => [ '-and', @groups ] }
+        if @groups;
+        
+    my @removed = $self->schema->resultset('LayoutGroup')->search($search,{
         select   => {
             max => 'group_id',
             -as => 'group_id',
@@ -1010,106 +933,100 @@ sub set_permissions
         group_by => 'group_id',
     })->get_column('group_id')->all;
 
-    foreach my $group_id (@$groups)
-    {
-        my $has_read;
-        my @permissions = $permissions->{$group_id} ? @{$permissions->{$group_id}} : ();
+    $self->schema->resultset('LayoutGroup')->search({
+        layout_id => $self->id,
+        group_id  => \@removed
+    })->delete;
 
-        # If no permissions exist for this group, and if we are adding standard
-        # permissions, then also add approval ones to ensure normal access is
-        # possible by default
-        if ($type eq 'access' && !$self->schema->resultset('LayoutGroup')->search({
+    foreach my $group_id (@groups) {
+        my @new_permissions = $permissions{$group_id};  
+
+        my $existing_rs = $self->schema->resultset('LayoutGroup')->search({
+            layout_id  => $self->id,
+            group_id   => $group_id,
+        });
+
+        my @existing_permissions = map { $_->permission } $existing_rs->all;
+
+        my $lc = List::Compare->new(\@new_permissions, \@existing_permissions);
+
+        my @removed_permissions = $lc->get_complement();
+        my @added_permissions = $lc->unique();
+
+        my $read_removed = grep { $_ eq 'read' } @removed_permissions;
+
+        try {
+            $self->schema->resultset('LayoutGroup')->search({
                 layout_id  => $self->id,
                 group_id   => $group_id,
-            })->count
-        )
-        {
-            # Add both no-approval permissions regardless, in case of future
-            # standard edits. Having these permissions will only allow anything
-            # if a standard write is added anyway
-            push @permissions, 'write_new_no_approval', 'write_existing_no_approval';
-        }
+                permission => \@removed_permissions
+            })->delete;
+        };
+        # Log any messages from try block, but only as trace
+        $@->reportAll(reason => 'TRACE');
 
-        foreach my $permission (@permissions)
-        {
-            $has_read = 1 if $permission eq 'read';
-            # Unique constraint on table. Catch existing.
+        foreach my $added (@added_permissions) {
             try {
                 $self->schema->resultset('LayoutGroup')->create({
                     layout_id  => $self->id,
                     group_id   => $group_id,
-                    permission => $permission,
+                    permission => $added
                 });
             };
             # Log any messages from try block, but only as trace
             $@->reportAll(reason => 'TRACE');
         }
 
-        # Before we do the catch-all delete, see if there is currently a
-        # read permission there which is about to be removed.
-        my $read_removed = !$has_read && $self->schema->resultset('LayoutGroup')->search({
-            group_id   => $group_id,
-            layout_id  => $self->id,
-            permission => 'read',
-        })->count;
-
-        # Delete those no longer there
-        my $search = { group_id => $group_id, layout_id => $self->id };
-        foreach (qw/read write_new write_existing approve_new approve_existing
-            write_new_no_approval write_existing_no_approval/)
-        {
-            push @permissions, $_ if !$options{permissions} && !exists $options{$_};
-        }
-        $search->{permission} = { '!=' => [ '-and', @permissions ] } if @permissions;
-        $self->schema->resultset('LayoutGroup')->search($search)->delete;
-
-        # See if any read permissions have been removed. If so, we need
-        # to remove them from the relevant filters and sorts. The views themselves
-        # don't matter, as they won't be shown anyway.
-        if ($read_removed)
-        {
+        if ($read_removed) {
             # First the sorts
-            foreach my $sort ($self->schema->resultset('Sort')->search({
+            my @sorts = $self->schema->resultset('Sort')->search({
                 layout_id      => $self->id,
                 'view.user_id' => { '!=' => undef },
             }, {
                 prefetch => 'view',
-            })->all)
-            {
+            })->all;
+
+            foreach my $sort (@sorts) {
                 # For each sort on this column, which no longer has read.
                 # See if user attached to this view still has access with
                 # another group
                 $sort->delete unless $self->user_id_can($sort->view->user_id, 'read');
             }
+
             # Then the filters
-            foreach my $filter ($self->schema->resultset('Filter')->search({
+            my @filters = $self->schema->resultset('Filter')->search({
                 layout_id      => $self->id,
                 'view.user_id' => { '!=' => undef },
             }, {
                 prefetch => 'view',
-            })->all)
-            {
+            })->all;
+
+            foreach my $filter (@filters) {
                 # For each sort on this column, which no longer has read.
                 # See if user attached to this view still has access with
                 # another group
-                unless ($self->user_id_can($filter->view->user_id, 'read'))
-                {
-                    # Filter cache
-                    $filter->delete;
-                    # Alert cache
-                    $self->schema->resultset('AlertCache')->search({
-                        layout_id => $self->id,
-                        view_id   => $filter->view_id,
-                    })->delete;
-                    # Column in the view
-                    $self->schema->resultset('ViewLayout')->search({
-                        layout_id => $self->id,
-                        view_id   => $filter->view_id,
-                    })->delete;
-                    # And the JSON filter itself
-                    my $filtered = _filter_remove_colid($self, $filter->view->filter);
-                    $filter->view->update({ filter => $filtered });
-                }
+
+                next if $self->user_id_can($filter->view->user_id, 'read');
+
+                # Filter cache
+                $filter->delete;
+
+                # Alert cache
+                $self->schema->resultset('AlertCache')->search({
+                    layout_id => $self->id,
+                    view_id   => $filter->view_id,
+                })->delete;
+
+                # Column in the view
+                $self->schema->resultset('ViewLayout')->search({
+                    layout_id => $self->id,
+                    view_id   => $filter->view_id,
+                })->delete;
+
+                # And the JSON filter itself
+                my $filtered = _filter_remove_colid($self, $filter->view->filter);
+
+                $filter->view->update({ filter => $filtered });
             }
         }
     }

--- a/lib/GADS/Type/Permission.pm
+++ b/lib/GADS/Type/Permission.pm
@@ -32,8 +32,8 @@ sub long {
     my $self = shift;
     $self->short or return "";
       $self->short eq 'read'                       ? 'Read values'
-    : $self->short eq 'write_new'                  ? 'Enter values for new records'
-    : $self->short eq 'write_existing'             ? 'Edit values of existing records'
+    : $self->short eq 'write_new'                  ? 'Enter values for new records, requiring approval'
+    : $self->short eq 'write_existing'             ? 'Edit values of existing records, requiring approval'
     : $self->short eq 'approve_new'                ? 'Approve values in new records'
     : $self->short eq 'approve_existing'           ? 'Approve changes in existing records'
     : $self->short eq 'write_new_no_approval'      ? 'Enter values for new records without requiring approval'

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1324,3 +1324,7 @@ small.search_term {
 .controls {
   padding-top: .5em;
   border-top: 1px solid #ddd; }
+
+/* manage-fields */
+.manage-fields .permissions ul {
+  list-style-type: none; }

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1492,7 +1492,8 @@ small.search_term {
 
 #current-permissions .permission .group-name {
   font-size: 1.2em;
-  margin-top: 0; }
+  margin-top: 0;
+  display: inline-block; }
 
 #current-permissions .configuration .tooltip {
   padding: .3em;

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1098,11 +1098,9 @@ a.list-group-item-danger.active, a.list-group-item-danger.active:hover, a.list-g
 .well-sm {
   border-radius: 0px; }
 
-.close {
+.modal .close {
   font-size: 22.5px;
-  font-weight: bold; }
-
-button.close {
+  font-weight: bold;
   background: transparent; }
 
 .modal {
@@ -1339,6 +1337,9 @@ small.search_term {
   border-bottom: 1px solid #bbb;
   padding-bottom: .5em; }
 
+#manage-fields #permissions {
+  margin-top: 1em; }
+
 #manage-fields #permissions ul {
   list-style-type: none;
   padding: 0; }
@@ -1402,7 +1403,64 @@ small.search_term {
   padding: 0; }
 
 #manage-fields .permission-rule,
-#manage-fields .display-condition {
+#manage-fields .display-condition,
+#manage-fields .permission {
   background-color: #eee;
   border: 1px solid #ccc;
   padding: .5em; }
+
+.permission .abbreviation {
+  border-bottom: 1px dashed #000;
+  cursor: help;
+  margin: 0 .2em; }
+
+#current-permissions .legend dd,
+#current-permissions .legend dt {
+  display: inline-block; }
+
+#current-permissions .legend dt {
+  width: 15%; }
+
+#current-permissions .legend dd {
+  width: 84%; }
+
+#current-permissions .configuration {
+  position: relative; }
+
+[role="tooltip"] .tooltip,
+[role="tooltip"] + .tooltip {
+  padding: .5em;
+  top: -2.7em;
+  right: -5em;
+  border: 1px solid #000;
+  background-color: #fff; }
+
+[role="tooltip"]:focus .tooltip.visually-hidden,
+[role="tooltip"]:active .tooltip.visually-hidden,
+[role="tooltip"]:hover .tooltip.visually-hidden,
+[role="tooltip"]:focus + .tooltip.visually-hidden,
+[role="tooltip"]:active + .tooltip.visually-hidden,
+[role="tooltip"]:hover + .tooltip.visually-hidden {
+  clip: auto;
+  height: auto;
+  margin: auto;
+  overflow: auto;
+  padding: initial;
+  position: absolute;
+  width: auto;
+  opacity: 1; }
+
+#current-permissions .permission .group-name {
+  font-size: 1.2em;
+  margin-top: 0; }
+
+#current-permissions .configuration .tooltip {
+  padding: .3em;
+  font-size: 1em;
+  top: -3em;
+  right: auto;
+  left: 0; }
+
+#current-permissions .summary {
+  width: 75%;
+  display: inline-block; }

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1445,6 +1445,15 @@ small.search_term {
 #current-permissions .permission.edit button.edit {
   display: none; }
 
+#current-permissions button.delete {
+  display: none; }
+
+#current-permissions .permission {
+  margin-bottom: 1em; }
+
+#current-permissions .permission.edit button.delete {
+  display: inline; }
+
 #current-permissions .legend dd,
 #current-permissions .legend dt {
   display: inline-block; }

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1415,6 +1415,32 @@ small.search_term {
   cursor: help;
   margin: 0 .2em; }
 
+#current-permissions .permission-read .abbreviation-read {
+  display: inline; }
+
+#current-permissions .permission-write-new .abbreviation-write-new {
+  display: inline; }
+
+#current-permissions .permission-write-existing .abbreviation-write-existing {
+  display: inline; }
+
+#current-permissions .permission-approve-new .abbreviation-approve-new {
+  display: inline; }
+
+#current-permissions .permission-approve-existing .abbreviation-approve-existing {
+  display: inline; }
+
+#current-permissions .permission-write-new-no-approval .abbreviation-write-new-no-approval {
+  display: inline; }
+
+#current-permissions .permission-write-existing-no-approval .abbreviation-write-existing-no-approval {
+  display: inline; }
+
+#current-permissions .abbreviation,
+#current-permissions .permission.edit .configuration,
+#current-permissions .permission.edit button.edit {
+  display: none; }
+
 #current-permissions .legend dd,
 #current-permissions .legend dt {
   display: inline-block; }

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1325,10 +1325,16 @@ small.search_term {
   margin-bottom: 0.2em; }
 
 .controls {
-  padding-top: .5em;
-  border-top: 1px solid #ddd; }
+  padding-top: .5em; }
 
 /* manage-fields */
+.manage-fields {
+  border-bottom: 1px solid #bbb;
+  padding-bottom: .5em; }
+
 .manage-fields .permissions ul {
   list-style-type: none;
   padding: 0; }
+
+.manage-fields h4 {
+  display: inline; }

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1401,7 +1401,8 @@ small.search_term {
   margin: 0;
   padding: 0; }
 
-#manage-fields .permission-rule {
+#manage-fields .permission-rule,
+#manage-fields .display-condition {
   background-color: #eee;
   border: 1px solid #ccc;
   padding: .5em; }

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1320,3 +1320,7 @@ small.search_term {
   vertical-align: bottom;
   margin-left: 0.2em;
   margin-bottom: 0.2em; }
+
+.controls {
+  padding-top: .5em;
+  border-top: 1px solid #ddd; }

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1328,13 +1328,47 @@ small.search_term {
   padding-top: .5em; }
 
 /* manage-fields */
-.manage-fields {
+#manage-fields {
   border-bottom: 1px solid #bbb;
   padding-bottom: .5em; }
 
-.manage-fields #permissions ul {
+#manage-fields #permissions ul {
   list-style-type: none;
   padding: 0; }
 
-.manage-fields h4 {
+#manage-fields h4 {
   display: inline; }
+
+#manage-fields .field-options {
+  display: none; }
+
+#manage-fields.column-type-calc .field-options.calc {
+  display: block; }
+
+#manage-fields.column-type-rag .field-options.rag {
+  display: block; }
+
+#manage-fields.column-type-tree .field-options.tree {
+  display: block; }
+
+#manage-fields.column-type-enum .field-options.enum {
+  display: block; }
+
+#manage-fields.column-type-file .field-options.file {
+  display: block; }
+
+#manage-fields.column-type-curval .field-options.curval {
+  display: block; }
+
+#manage-fields.column-type-string .field-options.string {
+  display: block; }
+
+#manage-fields.column-type-date .field-options.date {
+  display: block; }
+
+#manage-fields.column-type-daterange .field-options.daterange {
+  display: block; }
+
+#manage-fields.column-type-rag #options .stored-value,
+#manage-fields.column-type-calc #options .stored-value {
+  display: none; }

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1,3 +1,23 @@
+/* a11y-related */
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px; }
+
+.visually-hidden-opacity {
+  opacity: 0; }
+
+/* general util */
+.clearfix::after {
+  content: "";
+  display: block;
+  clear: both; }
+
 /*! normalize.css v3.0.0 | MIT License | git.io/normalize */
 @font-face {
   font-family: 'Open Sans remote';
@@ -1134,20 +1154,6 @@ button.close {
 .carousel-control .icon-prev, .carousel-control .icon-next {
   margin-left: -10px; }
 
-/* a11y-related */
-.visually-hidden {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px; }
-
-.visually-hidden-opacity {
-  opacity: 0; }
-
 /* Login page - Remember Username */
 .remember-me, .reset-password {
   display: inline-block;
@@ -1243,7 +1249,8 @@ small.search_term {
 .expandable {
   display: none; }
 
-.trigger[aria-expanded="true"] + .expandable {
+.trigger[aria-expanded="true"] + .expandable,
+.expandable.expanded {
   display: block; }
 
 /* Person contact details popover */
@@ -1336,11 +1343,13 @@ small.search_term {
   list-style-type: none;
   padding: 0; }
 
-#manage-fields h4 {
-  display: inline; }
-
 #manage-fields .field-options {
-  display: none; }
+  display: none;
+  border: 1px solid #ccc;
+  padding: .5em;
+  margin: .5em;
+  margin-right: 0;
+  background-color: #eee; }
 
 #manage-fields.column-type-calc .field-options.calc {
   display: block; }
@@ -1372,3 +1381,27 @@ small.search_term {
 #manage-fields.column-type-rag #options .stored-value,
 #manage-fields.column-type-calc #options .stored-value {
   display: none; }
+
+#manage-fields #advanced-field-settings h3,
+#manage-fields h4 {
+  display: inline-block;
+  border-bottom: 1px solid #bbb;
+  padding-bottom: .5em; }
+
+#manage-fields .permission.write-new .permission,
+#manage-fields .permission.modify-existing .permission {
+  display: none;
+  margin-left: 1.5em; }
+
+#manage-fields .permission.write-new input:checked ~ .permission,
+#manage-fields .permission.modify-existing input:checked ~ .permission {
+  display: block; }
+
+#manage-fields .permission-rule h5 {
+  margin: 0;
+  padding: 0; }
+
+#manage-fields .permission-rule {
+  background-color: #eee;
+  border: 1px solid #ccc;
+  padding: .5em; }

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1418,23 +1418,27 @@ small.search_term {
 #current-permissions .permission-read .abbreviation-read {
   display: inline; }
 
-#current-permissions .permission-write-new .abbreviation-write-new {
-  display: inline; }
-
-#current-permissions .permission-write-existing .abbreviation-write-existing {
-  display: inline; }
-
 #current-permissions .permission-approve-new .abbreviation-approve-new {
   display: inline; }
 
 #current-permissions .permission-approve-existing .abbreviation-approve-existing {
   display: inline; }
 
+#current-permissions .permission-write-new .abbreviation-write-new {
+  display: inline; }
+
 #current-permissions .permission-write-new-no-approval .abbreviation-write-new-no-approval {
+  display: inline; }
+
+#current-permissions .permission-write-existing .abbreviation-write-existing {
   display: inline; }
 
 #current-permissions .permission-write-existing-no-approval .abbreviation-write-existing-no-approval {
   display: inline; }
+
+#current-permissions .permission.permission-write-new .abbreviation-write-new-no-approval,
+#current-permissions .permission.permission-write-existing .abbreviation-write-existing-no-approval {
+  display: none; }
 
 #current-permissions .abbreviation,
 #current-permissions .permission.edit .configuration,

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1332,7 +1332,7 @@ small.search_term {
   border-bottom: 1px solid #bbb;
   padding-bottom: .5em; }
 
-.manage-fields .permissions ul {
+.manage-fields #permissions ul {
   list-style-type: none;
   padding: 0; }
 

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1410,7 +1410,8 @@ small.search_term {
   padding: .5em; }
 
 .permission .abbreviation {
-  border-bottom: 1px dashed #000;
+  border: 1px dashed #000;
+  padding: .2em;
   cursor: help;
   margin: 0 .2em; }
 

--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -17,6 +17,9 @@
 html {
   font-family: 'Open Sans remote',sans-serif; }
 
+[hidden] {
+  display: none; }
+
 #wrapper {
   width: 95%;
   border-top: 5px solid #1460aa;
@@ -1327,4 +1330,5 @@ small.search_term {
 
 /* manage-fields */
 .manage-fields .permissions ul {
-  list-style-type: none; }
+  list-style-type: none;
+  padding: 0; }

--- a/public/js/linkspace.js
+++ b/public/js/linkspace.js
@@ -1,33 +1,33 @@
+var positionDisclosure = function (offsetTop, offsetLeft, triggerHeight) {
+    var $disclosure = this;
+
+    var left = (offsetLeft) + 'px';
+    var top  = (offsetTop + triggerHeight ) + 'px';
+
+    $disclosure.css({
+        'left': left,
+        'top' : top
+    });
+};
+
+var toggleDisclosure = function () {
+    var $trigger = $(this);
+    var $disclosure = $trigger.next('.expandable');
+
+    var offset = $trigger.position();
+    positionDisclosure.call(
+        $disclosure, offset.top, offset.left, $trigger.height()
+    );
+
+    var currentlyExpanded = $trigger.attr('aria-expanded') === 'true';
+    $trigger.attr('aria-expanded', !currentlyExpanded);
+    
+    $disclosure.toggleClass('expanded', !currentlyExpanded);
+
+    $trigger.trigger((currentlyExpanded ? 'collapse' : 'expand'), $disclosure);
+};
+
 var setupDisclosureWidgets = function () {
-    var positionDisclosure = function (offsetTop, offsetLeft, triggerHeight) {
-        var $disclosure = this;
-
-        var left = (offsetLeft) + 'px';
-        var top  = (offsetTop + triggerHeight ) + 'px';
-
-        $disclosure.css({
-            'left': left,
-            'top' : top
-        });
-    };
-
-    var toggleDisclosure = function () {
-        var $trigger = $(this);
-        var $disclosure = $trigger.next('.expandable');
-
-        var offset = $trigger.position();
-        positionDisclosure.call(
-            $disclosure, offset.top, offset.left, $trigger.height()
-        );
-
-        var currentlyExpanded = $trigger.attr('aria-expanded') === 'true';
-        $trigger.attr('aria-expanded', !currentlyExpanded);
-        
-        $disclosure.toggleClass('expanded', !currentlyExpanded);
-
-        $trigger.trigger((currentlyExpanded ? 'collapse' : 'expand'), $disclosure);
-    };
-
     $('.trigger[aria-expanded]').on('click', toggleDisclosure);
 }
 
@@ -52,14 +52,34 @@ var Linkspace = {
 
 Linkspace.layout = function () {
     Linkspace.debug('Layout JS firing');
+
     $('#show-advanced-field-settings').on('expand', function (event, target) {
         $(target).find('h3').focus();
         $(this).remove();
     });
-    $('#current-permissions .permission').each(function () {
+
+    var $config = $('#permission-configuration');
+    var $rule = $('.permission-rule');
+
+    var $ruleTemplate = $('#permission-rule-template');
+    var $cancelRuleButton = $rule.find('button.cancel-permission');
+    var $addRuleButton = $rule.find('button.add-permission'); 
+
+    var closePermissionConfig = function () {
+        $config.find('input').each(function () {
+            $(this).prop('checked', false);
+        });
+        $config.attr('hidden', '');
+        $('#configure-permissions').removeAttr('hidden').focus();
+    };
+
+    var handlePermissionChange = function () {
         var $permission = $(this);
-        var $editButton  = $permission.find('button.edit');
-        var $okButton    = $permission.find('button.ok');
+        var groupId = $permission.data('group-id');
+
+        var $editButton   = $permission.find('button.edit');
+        var $deleteButton = $permission.find('button.delete');
+        var $okButton     = $permission.find('button.ok');
 
         $permission.find('input').on('change', function () {
             var pClass = 'permission-' + $(this).data('permission-class');
@@ -75,9 +95,14 @@ Linkspace.layout = function () {
             });
         });
 
-        $editButton.on('expand', function (event, target) {
+        $editButton.on('expand', function (event) {
             $permission.addClass('edit');
             $permission.find('h7').focus();
+        });
+
+        $deleteButton.on('click', function (event) {
+            $('#permissions').removeClass('permission-group-' + groupId);
+            $permission.remove();
         });
 
         $okButton.on('click', function (event) {
@@ -85,7 +110,54 @@ Linkspace.layout = function () {
             $okButton.parent().removeClass('expanded');
             $editButton.attr('aria-expanded', false).focus();
         });
+    };
+
+    $cancelRuleButton.on('click', closePermissionConfig);
+
+    $addRuleButton.on('click', function () {
+        var $newRule = $($ruleTemplate.html());
+        var $currentPermissions = $('#current-permissions ul');
+        var $selectedGroup = $config.find('option:selected');
+
+        var groupId = $selectedGroup.val();
+
+        $config.find('input').each(function () {
+            var $input = $(this);
+            var state = $input.prop('checked');
+
+            if (state) {
+                $newRule.addClass(
+                    'permission-' +
+                    $input.data('permission-class').replace(/_/g,'-')
+                );
+            }
+
+            $newRule.find('input#' + $input.attr('id'))
+                .prop('checked', state)
+                .attr('id', $input.attr('id') + groupId)
+                .attr('name', $input.attr('name') + groupId)
+                .next('label').attr('for', $input.attr('id'));
+        });
+
+        $newRule.appendTo($currentPermissions);
+        $newRule.attr('data-group-id', groupId);
+
+        $('#permissions').addClass('permission-group-' + groupId);
+        $newRule.find('.group-name').text($selectedGroup.text());
+
+        $newRule.find('button.edit').on('click', toggleDisclosure);
+
+        handlePermissionChange.call($newRule);
+        closePermissionConfig();
     });
+
+    $('#configure-permissions').on('click', function () {
+        $(this).attr('hidden', '');
+        $('#permission-configuration').removeAttr('hidden');
+        $(this).parent().find('h4').focus();
+    }); 
+
+    $('#current-permissions .permission').each(handlePermissionChange);
 };
 
 $(Linkspace.init);

--- a/public/js/linkspace.js
+++ b/public/js/linkspace.js
@@ -97,7 +97,7 @@ Linkspace.layout = function () {
 
         $editButton.on('expand', function (event) {
             $permission.addClass('edit');
-            $permission.find('h7').focus();
+            $permission.find('.group-name').focus();
         });
 
         $deleteButton.on('click', function (event) {
@@ -152,8 +152,25 @@ Linkspace.layout = function () {
     });
 
     $('#configure-permissions').on('click', function () {
+        var $permissions = $('#permissions');
+        var selected = false;
+        $('#permission-configuration').find('option').each(function () {
+            var $option = $(this);
+            console.debug($option.text(), $option);
+            $option.removeAttr('disabled');
+            if ($permissions.hasClass('permission-group-' + $option.val())) {
+                $option.attr('disabled', '');
+            } else {
+                // make sure the first non-disabled option gets selected
+                if (!selected) {
+                    $option.attr('selected', '');
+                    selected = true;
+                }
+            }
+        });
         $(this).attr('hidden', '');
         $('#permission-configuration').removeAttr('hidden');
+
         $(this).parent().find('h4').focus();
     }); 
 

--- a/public/js/linkspace.js
+++ b/public/js/linkspace.js
@@ -156,7 +156,6 @@ Linkspace.layout = function () {
         var selected = false;
         $('#permission-configuration').find('option').each(function () {
             var $option = $(this);
-            console.debug($option.text(), $option);
             $option.removeAttr('disabled');
             if ($permissions.hasClass('permission-group-' + $option.val())) {
                 $option.attr('disabled', '');

--- a/public/js/linkspace.js
+++ b/public/js/linkspace.js
@@ -56,6 +56,36 @@ Linkspace.layout = function () {
         $(target).find('h3').focus();
         $(this).remove();
     });
+    $('#current-permissions .permission').each(function () {
+        var $permission = $(this);
+        var $editButton  = $permission.find('button.edit');
+        var $okButton    = $permission.find('button.ok');
+
+        $permission.find('input').on('change', function () {
+            var pClass = 'permission-' + $(this).data('permission-class');
+            var checked = $(this).prop('checked');
+            $permission.toggleClass(pClass, checked);
+
+            if (checked) { return; }
+
+            $(this).siblings('div').find('input').each(function () {
+                $(this).prop(checked);
+                pClass = 'permission-' + $(this).data('permission-class');
+                $permission.toggleClass(pClass, checked);
+            });
+        });
+
+        $editButton.on('expand', function (event, target) {
+            $permission.addClass('edit');
+            $permission.find('h7').focus();
+        });
+
+        $okButton.on('click', function (event) {
+            $permission.removeClass('edit');
+            $okButton.parent().removeClass('expanded');
+            $editButton.attr('aria-expanded', false).focus();
+        });
+    });
 };
 
 $(Linkspace.init);

--- a/public/js/linkspace.js
+++ b/public/js/linkspace.js
@@ -22,15 +22,40 @@ var setupDisclosureWidgets = function () {
 
         var currentlyExpanded = $trigger.attr('aria-expanded') === 'true';
         $trigger.attr('aria-expanded', !currentlyExpanded);
+        
+        $disclosure.toggleClass('expanded', !currentlyExpanded);
+
+        $trigger.trigger((currentlyExpanded ? 'collapse' : 'expand'), $disclosure);
     };
 
     $('.trigger[aria-expanded]').on('click', toggleDisclosure);
 }
 
+var runPageSpecificCode = function () {
+    var page = $('body').data('page');
+    var handler = Linkspace[page];
+    if (handler !== undefined) {
+        handler();
+    }
+};
+
 var Linkspace = {
     init: function () {
+        console.clear();
         setupDisclosureWidgets();
+        runPageSpecificCode();
+    },
+    debug: function (msg) {
+        console.debug('[LINKSPACE]', msg);
     }
+};
+
+Linkspace.layout = function () {
+    Linkspace.debug('Layout JS firing');
+    $('#show-advanced-field-settings').on('expand', function (event, target) {
+        $(target).find('h3').focus();
+        $(this).remove();
+    });
 };
 
 $(Linkspace.init);

--- a/sass/_utility-classes.scss
+++ b/sass/_utility-classes.scss
@@ -1,0 +1,24 @@
+/* a11y-related */
+
+.visually-hidden {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+}
+
+.visually-hidden-opacity {
+    opacity: 0;
+}
+
+/* general util */
+
+.clearfix::after {
+    content: "";
+    display: block;
+    clear: both;
+}

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1468,3 +1468,9 @@ small.search_term {
     padding-top: .5em;
     border-top: 1px solid #ddd;
 }
+
+/* manage-fields */
+
+.manage-fields .permissions ul {
+    list-style-type: none;
+}

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1530,8 +1530,13 @@ small.search_term {
     margin: 0 .2em;
 }
 
-@each $abbr-type in read write-new write-existing approve-new approve-existing write-new-no-approval write-existing-no-approval {
+@each $abbr-type in read approve-new approve-existing write-new write-new-no-approval write-existing write-existing-no-approval {
     #current-permissions .permission-#{$abbr-type} .abbreviation-#{$abbr-type} { display: inline; }
+}
+
+#current-permissions .permission.permission-write-new .abbreviation-write-new-no-approval,
+#current-permissions .permission.permission-write-existing .abbreviation-write-existing-no-approval {
+    display: none;
 }
 
 #current-permissions .abbreviation,

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1472,12 +1472,20 @@ small.search_term {
 
 .controls {
     padding-top: .5em;
-    border-top: 1px solid #ddd;
 }
 
 /* manage-fields */
 
+.manage-fields {
+    border-bottom: 1px solid #bbb;
+    padding-bottom: .5em;
+}
+
 .manage-fields .permissions ul {
     list-style-type: none;
     padding: 0;
+}
+
+.manage-fields h4 {
+    display: inline;
 }

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1,5 +1,5 @@
 @import 'branding-colours';
-
+@import 'utility-classes';
 
 /*! normalize.css v3.0.0 | MIT License | git.io/normalize */
 
@@ -1229,23 +1229,6 @@ button.close {
         margin-left: -10px;
 }
 
-/* a11y-related */
-
-.visually-hidden {
-    border: 0;
-    clip: rect(0 0 0 0);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    width: 1px;
-}
-
-.visually-hidden-opacity {
-    opacity: 0;
-}
-
 /* Login page - Remember Username */
 
 .remember-me, .reset-password {
@@ -1368,7 +1351,8 @@ small.search_term {
     display: none;
 }
 
-.trigger[aria-expanded="true"] + .expandable {
+.trigger[aria-expanded="true"] + .expandable,
+.expandable.expanded {
     display: block; 
 }
 
@@ -1486,11 +1470,14 @@ small.search_term {
     padding: 0;
 }
 
-#manage-fields h4 {
-    display: inline;
+#manage-fields .field-options { 
+    display: none; 
+    border: 1px solid #ccc;
+    padding: .5em;
+    margin: .5em;
+    margin-right: 0;
+    background-color: #eee;
 }
-
-#manage-fields .field-options { display: none; }
 
 @each $column-type in calc rag tree enum file curval string date daterange {
     #manage-fields.column-type-#{$column-type} .field-options.#{$column-type} { display: block; }
@@ -1499,4 +1486,33 @@ small.search_term {
 #manage-fields.column-type-rag #options .stored-value,
 #manage-fields.column-type-calc #options .stored-value {
     display: none;
+}
+
+#manage-fields #advanced-field-settings h3,
+#manage-fields h4 {
+    display: inline-block;
+    border-bottom: 1px solid #bbb;
+    padding-bottom: .5em;
+}
+
+#manage-fields .permission.write-new .permission,
+#manage-fields .permission.modify-existing .permission {
+    display: none;
+    margin-left: 1.5em;
+}
+
+#manage-fields .permission.write-new input:checked ~ .permission,
+#manage-fields .permission.modify-existing input:checked ~ .permission {
+    display: block;
+}
+
+#manage-fields .permission-rule h5 {
+    margin: 0;
+    padding: 0;
+}
+
+#manage-fields .permission-rule {
+    background-color: #eee;
+    border: 1px solid #ccc;
+    padding: .5em;
 }

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1476,16 +1476,27 @@ small.search_term {
 
 /* manage-fields */
 
-.manage-fields {
+#manage-fields {
     border-bottom: 1px solid #bbb;
     padding-bottom: .5em;
 }
 
-.manage-fields #permissions ul {
+#manage-fields #permissions ul {
     list-style-type: none;
     padding: 0;
 }
 
-.manage-fields h4 {
+#manage-fields h4 {
     display: inline;
+}
+
+#manage-fields .field-options { display: none; }
+
+@each $column-type in calc rag tree enum file curval string date daterange {
+    #manage-fields.column-type-#{$column-type} .field-options.#{$column-type} { display: block; }
+}
+
+#manage-fields.column-type-rag #options .stored-value,
+#manage-fields.column-type-calc #options .stored-value {
+    display: none;
 }

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1530,6 +1530,16 @@ small.search_term {
     margin: 0 .2em;
 }
 
+@each $abbr-type in read write-new write-existing approve-new approve-existing write-new-no-approval write-existing-no-approval {
+    #current-permissions .permission-#{$abbr-type} .abbreviation-#{$abbr-type} { display: inline; }
+}
+
+#current-permissions .abbreviation,
+#current-permissions .permission.edit .configuration,
+#current-permissions .permission.edit button.edit {
+    display: none;
+}
+
 #current-permissions .legend dd,
 #current-permissions .legend dt {
     display: inline-block;
@@ -1546,6 +1556,7 @@ small.search_term {
 #current-permissions .configuration {
     position: relative;
 }
+
 
 @mixin visually-unhide {
     clip: auto;

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1448,6 +1448,7 @@ small.search_term {
 .rag .unexpected {
     border-bottom-color: $rag-unexpected;
     background-color: $rag-unexpected-bg;
+}
 
 /* Data table */
 
@@ -1461,4 +1462,9 @@ small.search_term {
     vertical-align: bottom;
     margin-left: 0.2em;
     margin-bottom: 0.2em;
+}
+
+.controls {
+    padding-top: .5em;
+    border-top: 1px solid #ddd;
 }

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1511,7 +1511,8 @@ small.search_term {
     padding: 0;
 }
 
-#manage-fields .permission-rule {
+#manage-fields .permission-rule,
+#manage-fields .display-condition {
     background-color: #eee;
     border: 1px solid #ccc;
     padding: .5em;

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1609,6 +1609,7 @@ small.search_term {
 #current-permissions .permission .group-name {
     font-size: 1.2em;
     margin-top: 0;
+    display: inline-block;
 }
 
 #current-permissions .configuration .tooltip {

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1481,7 +1481,7 @@ small.search_term {
     padding-bottom: .5em;
 }
 
-.manage-fields .permissions ul {
+.manage-fields #permissions ul {
     list-style-type: none;
     padding: 0;
 }

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1524,7 +1524,8 @@ small.search_term {
 }
 
 .permission .abbreviation {
-    border-bottom: 1px dashed #000;
+    border: 1px dashed #000;
+    padding: .2em;
     cursor: help;
     margin: 0 .2em;
 }

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1172,13 +1172,13 @@ a.list-group-item-danger.active,a.list-group-item-danger.active:hover,a.list-gro
 .well-sm {
         border-radius:0px;
 }
-.close {
+
+.modal .close {
         font-size:22.5px;
         font-weight:bold;
+        background: transparent;
 }
-button.close {
-        background:transparent;
-}
+
 .modal {
         overflow:auto;
         overflow-y:scroll;
@@ -1465,6 +1465,10 @@ small.search_term {
     padding-bottom: .5em;
 }
 
+#manage-fields #permissions {
+    margin-top: 1em;
+}
+
 #manage-fields #permissions ul {
     list-style-type: none;
     padding: 0;
@@ -1512,8 +1516,84 @@ small.search_term {
 }
 
 #manage-fields .permission-rule,
-#manage-fields .display-condition {
+#manage-fields .display-condition,
+#manage-fields .permission {
     background-color: #eee;
     border: 1px solid #ccc;
     padding: .5em;
 }
+
+.permission .abbreviation {
+    border-bottom: 1px dashed #000;
+    cursor: help;
+    margin: 0 .2em;
+}
+
+#current-permissions .legend dd,
+#current-permissions .legend dt {
+    display: inline-block;
+}
+
+#current-permissions .legend dt {
+    width: 15%;
+}
+
+#current-permissions .legend dd {
+    width: 84%;
+}
+
+#current-permissions .configuration {
+    position: relative;
+}
+
+@mixin visually-unhide {
+    clip: auto;
+    height: auto;
+    margin: auto;
+    overflow: auto;
+    padding: initial;
+    position: absolute;
+    width: auto;
+    opacity: 1;
+}
+
+[role="tooltip"]   .tooltip,
+[role="tooltip"] + .tooltip {
+    padding: .5em;
+    top: -2.7em;
+    right: -5em;
+
+    border: 1px solid #000;
+    background-color: #fff;
+}
+
+[role="tooltip"]:focus    .tooltip.visually-hidden,
+[role="tooltip"]:active   .tooltip.visually-hidden,
+[role="tooltip"]:hover    .tooltip.visually-hidden,
+[role="tooltip"]:focus  + .tooltip.visually-hidden,
+[role="tooltip"]:active + .tooltip.visually-hidden,
+[role="tooltip"]:hover  + .tooltip.visually-hidden {
+ 
+    @include visually-unhide;
+}
+
+#current-permissions .permission .group-name {
+    font-size: 1.2em;
+    margin-top: 0;
+}
+
+#current-permissions .configuration .tooltip {
+    padding: .3em;
+    font-size: 1em;
+    top: -3em;
+    right: auto;
+    left: 0;
+}
+
+#current-permissions .summary {
+    width: 75%;
+    display: inline-block;
+}
+
+
+

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -1545,6 +1545,18 @@ small.search_term {
     display: none;
 }
 
+#current-permissions button.delete {
+    display: none;
+}
+
+#current-permissions .permission {
+    margin-bottom: 1em;
+}
+
+#current-permissions .permission.edit button.delete {
+    display: inline;
+}
+
 #current-permissions .legend dd,
 #current-permissions .legend dt {
     display: inline-block;

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -58,12 +58,18 @@
 html {
   font-family: 'Open Sans remote',sans-serif;
 }
+
+[hidden] {
+    display: none;
+}
+
 #wrapper{
   width: 95%; 
   border-top: 5px solid $primary-navy; 
   margin-left: auto; 
   margin-right: auto; 
 }
+
 .hscroll{
   overflow-x: visible;
   margin-right: 20px;
@@ -1473,4 +1479,5 @@ small.search_term {
 
 .manage-fields .permissions ul {
     list-style-type: none;
+    padding: 0;
 }

--- a/t/010_permissions.t
+++ b/t/010_permissions.t
@@ -113,7 +113,7 @@ foreach my $column ($layout->all)
     $permissions->{$groups{limited}} = $all
         if $column->name eq 'string1';
     $permissions->{$groups{readwrite}} = $all;
-    $column->set_permissions(permissions => $permissions);
+    $column->set_permissions(%$permissions);
 }
 
 my $data_set = 'b';

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -123,8 +123,8 @@
                     [% END %]
 
                     [% IF groups.all.size %]
-                        <button aria-haspopup="true" class="btn btn-default" data-toggle="modal" data-target="#modal_access_control">Configure access</button>
-                        <button aria-haspopup="true" class="btn btn-default" data-toggle="modal" data-target="#modal_approval_control">Configure approval</button>
+                        <button type="button" aria-haspopup="true" class="btn btn-default" data-toggle="modal" data-target="#modal_access_control">Configure access</button>
+                        <button type="button" aria-haspopup="true" class="btn btn-default" data-toggle="modal" data-target="#modal_approval_control">Configure approval</button>
                     [% END %]
 
                     [% IF column.permissions.size %]

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -111,26 +111,31 @@
 [% BLOCK field_display_conditions %]
     <section id="display_conditions">
         <h4>Display</h4>
-    [% UNLESS column.display_field %]
+    [% UNLESS column.display_regex %]
         <p>This field is always displayed.</p>
         <button type="button" aria-expanded="false" class="trigger btn btn-default" id="add-display-regex">Configure display</button>
     [% END %]
-    <div class="row expandable">
-        <div class="form-group col-md-4">
-            <label for="display_field">Column</label>
-            <select class="form-control" id="display_field" name="display_field">
-                [% FOREACH field in all_columns %]
-                    <option value="[% field.id %]" [% IF column.display_field == field.id %]selected[% END %]>[% field.name | html_entity %]</option>
-                [% END %]
-            </select>
+    <div class="expandable [% column.display_regex && 'expanded' %]">
+        <p>This field will only be displayed under the following condition:</p>
+        <div class="display-condition clearfix">
+            <div class="clearfix">
+                    <button type="button" class="btn btn-sm btn-default pull-right" id="delete-display-condition">Delete condition</button>
+            </div>
+            <div class="form-group col-md-12">
+                <label for="display_field">Column</label>
+                <select class="form-control" id="display_field" name="display_field">
+                    [% FOREACH field in all_columns %]
+                        <option value="[% field.id %]" [% IF column.display_field == field.id %]selected[% END %]>[% field.name | html_entity %]</option>
+                    [% END %]
+                </select>
+            </div>
+            <div class="form-group col-md-12">
+                matches
+                <label for="display_regex">pattern</label>
+                [% whats_this('modalhelp_match') %]
+                <input type="text" class="form-control" id="display_regex" name="display_regex" value="[% column.display_regex | html_entity %]">
+            </div>
         </div>
-        <div class="col-md-3">
-            <p>matches [% whats_this('modalhelp_match') %]</p>
-        </div>
-        <div class="col-md-5 form-group">
-            <label for="display_regex">pattern</label>
-            <input type="text" class="form-control" id="display_regex" name="display_regex" value="[% column.display_regex | html_entity %]">
-    </div>
     </div>
     </section>
 [% END %]

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -1,6 +1,8 @@
 [% PROCESS help.tt %]
 [% PROCESS snippets/util.tt %]
 
+<div class="manage-fields">
+
 [% IF column.defined %]
 <h2>[% IF column.id %]Edit field[% ELSE %]Add a field to [% instance_name | html %][% END %]</h2>
 
@@ -126,20 +128,28 @@
                     [% END %]
 
                     [% IF column.permissions.size %]
-                        <dl>
-                            <dt>Groups that can read:</dt>
+                    <section class="permissions">
+                        <h4>Groups that can read:</h4>
+                        <ul>
                             [% FOREACH g IN column.group_summary('read') %]
-                                <dd>[% g %]</dd>
+                            <li>[% g %]</li>
                             [% END %]
-                            <dt>Groups that can write new values:</dt>
+                        </ul>
+
+                        <h4>Groups that can write new values:</h4>
+                        <ul>
                             [% FOREACH g IN column.group_summary('write_new') %]
-                                <dd>[% g %]</dd>
+                            <li>[% g %]</li>
                             [% END %]
-                            <dt>Groups that can write existing values:</dt>
+                        </ul>
+
+                        <h4>Groups that can write existing values:</h4>
+                        <ul>
                             [% FOREACH g IN column.group_summary('write_existing') %]
-                                <dd>[% g %]</dd>
+                            <li>[% g %]</li>
                             [% END %]
-                        </dl>
+                        </ul>
+                    </sections>
                     [% END %]
                 [% ELSE %]
                     <p>Please save the field before adding permissions</p>
@@ -721,8 +731,9 @@ available permissions are detailed in the <a href="[% url.page %]/user/">Users m
     </tbody>
 </table>
 <button type="submit" id="submit_saceorder" name="saveposition" value="submit" class="btn btn-primary">Save order</button>
-<p></p>
 </form>
+
+</div> <!-- /manage-fields -->
 [% END %]
 
 <script type="text/javascript">

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -182,8 +182,8 @@
                 </div>
             </div>
         [% ELSE %]
-            <div class="col-md-12">This field is always displayed.</div>
-            <div class="col-md-12">
+            <div>This field is always displayed.</div>
+            <div>
                 <button type="button" class="btn btn-default" id="add_display_regex">Define condition</button>
             </div>
         [% END %]

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -1,4 +1,5 @@
 [% PROCESS help.tt %]
+[% PROCESS snippets/util.tt %]
 
 [% IF column.defined %]
 <h2>[% IF column.id %]Edit field[% ELSE %]Add a field to [% instance_name | html %][% END %]</h2>
@@ -37,7 +38,7 @@
                 <input type="text" class="form-control" id="description" name="description" value="[% column.description | html_entity %]">
             </div>
             <div class="form-group">
-                <label for="name_short"><span style="font-weight:normal">Short name: (<a href="" data-toggle="modal" data-target="#modalhelp_name_short">what&apos;s this?</a>)</span></label>
+                <label for="name_short"><span style="font-weight:normal">Short name: [% whats_this('modalhelp_name_short') %]</span></label>
                 <input type="text" class="form-control" id="name_short" name="name_short" value="[% column.name_short | html_entity %]">
             </div>
             <div class="form-group">
@@ -98,7 +99,7 @@
                         </select>
                     </div>
                     <div class="col-md-2">
-                        <p>matches (<a href="" data-toggle="modal" data-target="#modalhelp_match">what&apos;s this?</a>)</p>
+                        <p>matches [% whats_this('modalhelp_match') %]</p>
                     </div>
                     <div class="col-md-5">
                         <div class="form-group">
@@ -108,7 +109,7 @@
                 </div>
             </div>
             <hr>
-            <h4>Permissions <small>(<a href="" data-toggle="modal" data-target="#modalhelp_groups">what&apos;s this?</a>)</small></h4>
+            <h3>Permissions [% whats_this('modalhelp_groups') %]</h3>
                 [% IF column.id %]
                     [% IF NOT column.permissions.size %]
                         <p>Access must be granted to this field before anyone (including you) can view and edit data in it.</p>
@@ -120,8 +121,8 @@
                     [% END %]
 
                     [% IF groups.all.size %]
-                        <a href="" class="btn btn-default" data-toggle="modal" data-target="#modal_access_control" data-title="Add another group">Access control...</a>
-                        <a href="" class="btn btn-default" data-toggle="modal" data-target="#modal_approval_control" data-title="Add another group">Approval control...</a>
+                        <button aria-haspopup="true" class="btn btn-default" data-toggle="modal" data-target="#modal_access_control">Configure access</button>
+                        <button aria-haspopup="true" class="btn btn-default" data-toggle="modal" data-target="#modal_approval_control">Configure approval</button>
                     [% END %]
 
                     [% IF column.permissions.size %]
@@ -313,7 +314,7 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="force_regex">Require the field value to be in a particular format: (<a href="" data-toggle="modal" data-target="#modalhelp_force_regex">what&apos;s this?</a>)</label>
+                    <label for="force_regex">Require the field value to be in a particular format: [% whats_this('modalhelp_force_regex') %]</label>
                     <input id="force_regex" class="form-control" type="text" name="force_regex" value="[% column.force_regex | html_entity %]">
                 </div>
             </div>
@@ -350,7 +351,7 @@
                     </select>
                 </div>
                 <div class="form-group">
-                    <label for="code_calc">Calculation: (<a href="" data-toggle="modal" data-target="#helpcalc">what&apos;s this?</a>)</label>
+                    <label for="code_calc">Calculation: [% whats_this('helpcalc') %]</label>
                     <textarea class="form-control monospace" id="code_calc" name="code_calc" rows="10">[% column.code | html_entity %]</textarea>
                 </div>
                 <div class="form-group">
@@ -388,7 +389,7 @@
                     Lua programming language.
                 </p>
                 <div class="form-group">
-                    <label for="code_rag">Conditions for this RAG status field: (<a href="" data-toggle="modal" data-target="#helpcalc">what&apos;s this?</a>)</label>
+                    <label for="code_rag">Conditions for this RAG status field: [% whats_this('helpcalc') %]</label>
                     <textarea class="form-control monospace" id="code_rag" name="code_rag" rows="10">[% column.code | html_entity %]</textarea>
                 </div>
                 <div class="form-group">
@@ -417,11 +418,15 @@
             </div>
         </div>
     </div>
-    <button type="submit" id="submit_save" name="submit" value="submit" class="btn btn-primary">[% IF column.id %]Save[% ELSE %]Save[% END %]</button>
-    [% IF column.id %]
-        <a href="/layout/" class="btn btn-default">Cancel</a>
-        <a href="" class="btn btn-default" data-toggle="modal" data-target="#myModal">Delete</a>
-    [% END %]
+    <div class="row controls">
+        <div class="col-md-12">
+            <button type="submit" id="submit_save" name="submit" value="submit" class="btn btn-primary">[% IF column.id %]Save[% ELSE %]Save[% END %]</button>
+        [% IF column.id %]
+            <a href="/layout/" class="btn btn-default">Cancel</a>
+            <a href="" class="btn btn-default" data-toggle="modal" data-target="#myModal">Delete</a>
+        [% END %]
+        </div>
+    </div>
 </form>
 <p></p>
        <!-- Modal -->

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -37,7 +37,7 @@
                 <input type="text" class="form-control" id="description" name="description" value="[% column.description | html_entity %]">
             </div>
             <div class="form-group">
-                <label for="name_short"><span style="font-weight:normal !important">Short name: (<a href="" data-toggle="modal" data-target="#modalhelp_name_short">?</a>)</span></label>
+                <label for="name_short"><span style="font-weight:normal">Short name: (<a href="" data-toggle="modal" data-target="#modalhelp_name_short">what&apos;s this?</a>)</span></label>
                 <input type="text" class="form-control" id="name_short" name="name_short" value="[% column.name_short | html_entity %]">
             </div>
             <div class="form-group">
@@ -98,7 +98,7 @@
                         </select>
                     </div>
                     <div class="col-md-2">
-                        <p>matches (<a href="" data-toggle="modal" data-target="#modalhelp_match">?</a>)</p>
+                        <p>matches (<a href="" data-toggle="modal" data-target="#modalhelp_match">what&apos;s this?</a>)</p>
                     </div>
                     <div class="col-md-5">
                         <div class="form-group">
@@ -108,7 +108,7 @@
                 </div>
             </div>
             <hr>
-            <h4>Permissions <small>(<a href="" data-toggle="modal" data-target="#modalhelp_groups">?</a>)</small></h4>
+            <h4>Permissions <small>(<a href="" data-toggle="modal" data-target="#modalhelp_groups">what&apos;s this?</a>)</small></h4>
                 [% IF column.id %]
                     [% IF NOT column.permissions.size %]
                         <p>Access must be granted to this field before anyone (including you) can view and edit data in it.</p>
@@ -313,7 +313,7 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="force_regex">Require the field value to be in a particular format: (<a href="" data-toggle="modal" data-target="#modalhelp_force_regex">?</a>)</label>
+                    <label for="force_regex">Require the field value to be in a particular format: (<a href="" data-toggle="modal" data-target="#modalhelp_force_regex">what&apos;s this?</a>)</label>
                     <input id="force_regex" class="form-control" type="text" name="force_regex" value="[% column.force_regex | html_entity %]">
                 </div>
             </div>
@@ -350,7 +350,7 @@
                     </select>
                 </div>
                 <div class="form-group">
-                    <label for="code_calc">Calculation: (<a href="" data-toggle="modal" data-target="#helpcalc">?</a>)</label>
+                    <label for="code_calc">Calculation: (<a href="" data-toggle="modal" data-target="#helpcalc">what&apos;s this?</a>)</label>
                     <textarea class="form-control monospace" id="code_calc" name="code_calc" rows="10">[% column.code | html_entity %]</textarea>
                 </div>
                 <div class="form-group">
@@ -388,7 +388,7 @@
                     Lua programming language.
                 </p>
                 <div class="form-group">
-                    <label for="code_rag">Conditions for this RAG status field: (<a href="" data-toggle="modal" data-target="#helpcalc">?</a>)</label>
+                    <label for="code_rag">Conditions for this RAG status field: (<a href="" data-toggle="modal" data-target="#helpcalc">what&apos;s this?</a>)</label>
                     <textarea class="form-control monospace" id="code_rag" name="code_rag" rows="10">[% column.code | html_entity %]</textarea>
                 </div>
                 <div class="form-group">

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -1,199 +1,15 @@
 [% PROCESS help.tt %]
 [% PROCESS snippets/util.tt %]
 [% PROCESS snippets/layout_permissions.tt %]
+[% PROCESS snippets/layout_modals.tt %]
 
-[% BLOCK layout_modals %]
-    <div class="modal fade" id="helprag" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="myModalLabel">RAG values</h4>
-                </div>
-                <div class="modal-body">
-                    <p>[% global.helptext.layout_rag %]</p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                </div>
-            </div><!-- /.modal-content -->
-        </div><!-- /.modal-dialog -->
-    </div><!-- /.modal -->
-
-    <!-- Modal -->
-    <div class="modal fade" id="helpcalc" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="myModalLabel">Calculated and RAG values</h4>
-                </div>
-                <div class="modal-body">
-                    <p>[% global.helptext.layout_calc %]</p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                </div>
-            </div><!-- /.modal-content -->
-        </div><!-- /.modal-dialog -->
-    </div><!-- /.modal -->
-   <!-- Modal -->
-    <div class="modal fade" id="modalhelp_match" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="myModalLabel">Matching field values</h4>
-                </div>
-                <div class="modal-body">
-                    <p>[% global.helptext.layout_match %]</p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                </div>
-            </div><!-- /.modal-content -->
-        </div><!-- /.modal-dialog -->
-    </div><!-- /.modal -->
-
-    <!-- Modal -->
-    <div class="modal fade" id="modalhelp_name_short" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="myModalLabel">Field short names</h4>
-                </div>
-                <div class="modal-body">
-                    <p>[% global.helptext.name_short %]</p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                </div>
-            </div><!-- /.modal-content -->
-        </div><!-- /.modal-dialog -->
-    </div><!-- /.modal -->
-   <!-- Modal -->
-
-    <div class="modal fade" id="modalhelp_groups" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="myModalLabel">Permissions</h4>
-                </div>
-                <div class="modal-body">
-                    <p>[% global.helptext.layout_groups %]</p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                </div>
-            </div><!-- /.modal-content -->
-        </div><!-- /.modal-dialog -->
-    </div><!-- /.modal -->
-   <!-- Modal -->
-
-    <div class="modal fade" id="modalhelp_force_regex" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="myModalLabel">Force input format</h4>
-                </div>
-                <div class="modal-body">
-                    <p>[% global.helptext.force_regex %]</p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                </div>
-            </div><!-- /.modal-content -->
-        </div><!-- /.modal-dialog -->
-    </div><!-- /.modal -->
-   <!-- Modal -->
-    <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <form role="form" method="post" enctype="multipart/form-data">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title" id="myModalLabel">Are you sure?</h4>
-                </div>
-                <div class="modal-body">
-                    <p>Are you sure you want to delete this item? Deleting an item will also delete all its associated data.</p>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                    <button type="submit" name="delete" value="delete" class="btn btn-primary">Confirm deletion</button>
-                </div>
-                </form>
-            </div><!-- /.modal-content -->
-        </div><!-- /.modal-dialog -->
-    </div><!-- /.modal -->
-[% END %]
-
-[% BLOCK edit_field_left_column %]
-    <div class="col-md-6 col-sm-12 col-xs-12">
-        <section id="options">
-            <h3>Options</h3>
-
-            <div class="checkbox stored-value">
-                <label>
-                    <input type="checkbox" name="optional" [% IF column.optional %]checked[% END %]>This field is optional
-                </label>
-            </div>
-            <div class="checkbox stored-value">
-                <label>
-                    <input type="checkbox" name="remember" [% IF column.remember %]checked[% END %]>Remember last value for new entry
-                </label>
-            </div>
-            <div class="checkbox stored-value">
-                <label>
-                    <input type="checkbox" name="isunique" [% IF column.isunique %]checked[% END %]>The values for this field must be unique
-                </label>
-            </div>
-            [% IF column.can_multivalue %]
-                <div class="checkbox">
-                    <label>
-                        <input type="checkbox" name="multivalue" [% IF column.multivalue %]checked[% END %]>Allow multiple values
-                    </label>
-                </div>
-            [% END %]
-        </section>
-
-        <section id="display_conditions">
-            <h3>Display conditions</h3>
-        [% IF column.display_field %]
-            <div class="form-group">
-                <div class="row">
-                    <div class="col-md-5">
-                        <select class="form-control" id="display_field" name="display_field">
-                            [% FOREACH field in all_columns %]
-                                <option value="[% field.id %]" [% IF column.display_field == field.id %]selected[% END %]>[% field.name | html_entity %]</option>
-                            [% END %]
-                        </select>
-                    </div>
-                    <div class="col-md-2">
-                        <p>matches [% whats_this('modalhelp_match') %]</p>
-                    </div>
-                    <div class="col-md-5">
-                        <div class="form-group">
-                            <input type="text" class="form-control" id="display_regex" name="display_regex" value="[% column.display_regex | html_entity %]">
-                        </div>
-                    </div>
-                </div>
-            </div>
-        [% ELSE %]
-            <div>This field is always displayed.</div>
-            <div>
-                <button type="button" class="btn btn-default" id="add_display_regex">Define condition</button>
-            </div>
-        [% END %]
-        </section>
-
+[% BLOCK field_properties %]
+    <div class="col-lg-4 col-md-6 col-sm-8 col-xs-12">
         <section id="properties">
             <h3>Properties</h3>
 
             <div class="form-group">
-                <label for="name">Field name:</label>
+                <label for="name">Name:</label>
                 <input type="text" class="form-control" id="name" name="name" value="[% column.name | html_entity %]">
             </div>
             [% UNLESS column.id %]
@@ -214,30 +30,12 @@
                     </select>
                 </div>
             [% END %]
+
+            [% PROCESS field_type_properties %]
+
             <div class="form-group">
                 <label for="description">Description:</label>
                 <input type="text" class="form-control" id="description" name="description" value="[% column.description | html_entity %]">
-            </div>
-            <div class="form-group">
-                <label for="name_short"><span style="font-weight:normal">Short name: [% whats_this('modalhelp_name_short') %]</span></label>
-                <input type="text" class="form-control" id="name_short" name="name_short" value="[% column.name_short | html_entity %]">
-            </div>
-            <div class="form-group">
-                <label for="link_parent_id">Link to a field in another table:</label>
-                [% IF instance_layouts.size %]
-                    <select class="form-control" id="link_parent_id" name="link_parent_id">
-                        <option value="">&lt;Not linked&gt;</option>
-                        [% FOREACH l IN instance_layouts %]
-                            [% FOREACH c IN l.layout.all %]
-                                <option value="[% c.id %]" [% IF column.link_parent.id == c.id %]selected[% END %]>[% l.instance.name %] - [% c.name %]</option>
-                            [% END %]
-                        [% END %]
-                    </select>
-                [% ELSE %]
-                    <select class="form-control" id="link_parent_id" name="link_parent_id" disabled readonly>
-                        <option value="">&lt;No other datasheets exist&gt;</option>
-                    </select>
-                [% END %]
             </div>
             <div class="form-group">
                 <label for="helptext">Help text for the user:</label>
@@ -245,249 +43,336 @@
             </div>
         </section>
 
-        [% PROCESS layout_permissions %]
+        [% PROCESS advanced_field_settings %]
+   </div>
+[% END %]
 
+[% BLOCK advanced_field_settings %]
+    <button type="button" id="show-advanced-field-settings" class="btn btn-default trigger" aria-expanded="false">Advanced settings &rarr;</button>    
+    <div class="expandable" id="advanced-field-settings">
+
+        <h3 tabindex="-1">Advanced settings</h3>
+
+        [% PROCESS field_options %]
+
+        <div class="form-group">
+            <label for="name_short"><span style="font-weight:normal">Short name: [% whats_this('modalhelp_name_short') %]</span></label>
+            <input type="text" class="form-control" id="name_short" name="name_short" value="[% column.name_short | html_entity %]">
+        </div>
+        <div class="form-group">
+            <label for="link_parent_id">Link to a field in another table:</label>
+            [% IF instance_layouts.size %]
+                <select class="form-control" id="link_parent_id" name="link_parent_id">
+                    <option value="">&lt;Not linked&gt;</option>
+                    [% FOREACH l IN instance_layouts %]
+                        [% FOREACH c IN l.layout.all %]
+                            <option value="[% c.id %]" [% IF column.link_parent.id == c.id %]selected[% END %]>[% l.instance.name %] - [% c.name %]</option>
+                        [% END %]
+                    [% END %]
+                </select>
+            [% ELSE %]
+                <select class="form-control" id="link_parent_id" name="link_parent_id" disabled readonly>
+                    <option value="">&lt;No other datasheets exist&gt;</option>
+                </select>
+            [% END %]
+        </div>
+
+        [% PROCESS field_display_conditions %]
+        [% PROCESS layout_permissions %]
     </div>
 [% END %]
 
-[% BLOCK edit_field_right_column %]
-   <div class="col-md-6 col-sm-12 col-xs-12">
-        <div class="field-options tree">
-            [% IF column.id %]
-                <h4>Tree field options</h4>
-                <p>Each value in the tree is referred to as a node.</p>
-                <div class="checkbox">
-                    <label>
-                        <input type="checkbox" name="end_node_only" [% IF column.end_node_only %]checked[% END %]>
-                        Only let users select an end-node
-                    </label>
-                </div>
-                <h4>Tree nodes:</h4>
-                <div class="form-group">
-                        <button class="btn btn-success btn-sm" onclick="demo_create();" type="button">Add a node</button>
-                        <button class="btn btn-warning btn-sm" onclick="demo_rename();" type="button">Rename</button>
-                        <button class="btn btn-danger btn-sm" onclick="demo_delete();" type="button">Delete</button>
-                        <button class="btn btn-info btn-sm" onclick="$('#jstree_demo_div').jstree('open_all');" type="button">Expand tree</button>
-                        <button class="btn btn-info btn-sm" onclick="$('#jstree_demo_div').jstree('close_all');" type="button">Collapse tree</button>
-                        <div id="jstree_demo_div"></div>
-                </div>
-            [% ELSE %]
-                <p>Use a tree to structure the values that users can select into categories and sub-categories.</p>
-                <p>To create your tree, please save this field first, then edit it.</p>
-            [% END %]
+[% BLOCK field_options %]
+    <div class="checkbox stored-value">
+        <label>
+            <input type="checkbox" name="optional" [% IF column.optional %]checked[% END %]>This field is optional
+        </label>
+    </div>
+    <div class="checkbox stored-value">
+        <label>
+            <input type="checkbox" name="remember" [% IF column.remember %]checked[% END %]>Remember last value for new entry
+        </label>
+    </div>
+    <div class="checkbox stored-value">
+        <label>
+            <input type="checkbox" name="isunique" [% IF column.isunique %]checked[% END %]>The values for this field must be unique
+        </label>
+    </div>
+    [% IF column.can_multivalue %]
+        <div class="checkbox">
+            <label>
+                <input type="checkbox" name="multivalue" [% IF column.multivalue %]checked[% END %]>Allow multiple values
+            </label>
         </div>
-        <div class="field-options enum">
-            <h4>Dropdown field options</h4>
-            <div class="col-md-11">
-                <div class="form-group">
-                    <label for="enumval">Order dropdown values:</label>
-                    <select class="form-control" name="ordering">
-                        <option value="" [% IF NOT column.ordering %]selected[% END %]>As entered</option>
-                        <option value="asc" [% IF column.ordering == "asc" %]selected[% END %]>Ascending</option>
-                        <option value="desc" [% IF column.ordering == "desc" %]selected[% END %]>Descending</option>
-                    </select>
-                </div>
-            </div>
-            <div class="col-md-11">
-                <label for="enumval">Add dropdown values:</label>
-            </div>
-            <div id="legs">
-                [% FOREACH enumval IN column.enumvals %]
-                    [% UNLESS enumval.deleted %]
-                        <div class="request-row">
-                                <div class="col-md-11">
-                                    <p>
-                                    <input type="text" class="form-control" name="enumval[% enumval.id %]" value="[% enumval.value | html_entity %]">
-                                    </p>
-                                </div>
-                                <button type="button" class="close closeme pull-left">&times;</button>
-                        </div>
-                    [% END %]
+    [% END %]
+[% END %]
+
+
+[% BLOCK field_display_conditions %]
+    <section id="display_conditions">
+        <h4>Display</h4>
+    [% UNLESS column.display_field %]
+        <p>This field is always displayed.</p>
+        <button type="button" aria-expanded="false" class="trigger btn btn-default" id="add-display-regex">Configure display</button>
+    [% END %]
+    <div class="row expandable">
+        <div class="form-group col-md-4">
+            <label for="display_field">Column</label>
+            <select class="form-control" id="display_field" name="display_field">
+                [% FOREACH field in all_columns %]
+                    <option value="[% field.id %]" [% IF column.display_field == field.id %]selected[% END %]>[% field.name | html_entity %]</option>
                 [% END %]
-                <div class="request-add">
-                        <div class="col-md-11">
-                            <button type="button" class="btn btn-default add">
-                                Add value
-                            </button>
-                        </div>
-                </div>
-            </div>
+            </select>
         </div>
-        <div class="field-options curval">
-            <h4>Field options</h4>
-            [% IF instance_layouts.size %]
-                [% rti = column.refers_to_instance %]
-                <div class="form-group">
-                    <div class="radio">
-                        <label>
-                            <input type="radio" name="typeahead" value="0" [% IF NOT column.typeahead %]checked[% END %]>Provide values as a dropdown
-                        </label>
-                    </div>
-                    <div class="radio">
-                        <label>
-                            <input type="radio" name="typeahead" value="1" [% IF column.typeahead %]checked[% END %]>Provide values as an auto-complete textbox
-                        </label>
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label for="override_permissions">Permissions override:</label>
-                    <div class="checkbox">
-                        <label>
-                            <input id="override_permissions" type="checkbox" name="override_permissions" [% IF column.override_permissions %]checked[% END %]>Override any user permissions when selecting records for this field
-                        </label>
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label for="refers_to_instance">Use this table:</label>
-                    <select class="form-control" id="refers_to_instance" name="refers_to_instance">
-                        [% IF NOT rti %]
-                            <option></option>
-                        [% END %]
-                        [% FOREACH instance IN instance_layouts %]
-                            <option value="[% instance.instance.id %]" [% IF rti == instance.instance.id %]selected[% END %]>[% instance.instance.name | html_entity %]</option>
-                        [% END %]
-                    </select>
-                </div>
-                [% FOREACH instance IN instance_layouts %]
-                    <div id="instance_fields_[% instance.instance.id %]" class="instance_fields"
-                        [% IF (rti AND instance.instance.id != rti) OR NOT rti %]
-                            style="display:none"
-                        [% END %]
-                        >
-                        <div class="form-group">
-                            <label for="curval_instance">Show these fields:</label>
-                            [% FOREACH c IN instance.layout.all %]
-                                [% NEXT IF c.type == "curval" %]
-                                [% checked = "" %]
-                                [% IF instance.instance.id == rti AND column.has_curval_field(c.id) %]
-                                    [% checked = "checked" %]
-                                [% END %]
-                                <div class="checkbox">
-                                    <label>
-                                        <input type="checkbox" name="curval_field_ids" value="[% c.id %]" [% checked %]>[% c.name %]
-                                    </label>
-                                </div>
-                            [% END %]
-                        </div>
-                        <div class="form-group">
-                                <label for="builder[% instance.layout.instance_id %]">Apply the following filters to records in the selected table::</label>
-                                <div id="builder[% instance.layout.instance_id %]"></div>
-                        </div>
-                    </div>
-                [% END %]
-                <input id="filter" type="hidden" name="filter" value="[% column.filter.as_json | html_entity %]">
-            [% ELSE %]
-                <div class="alert alert-info">
-                    No other instances are available to select data from
-                </div>
-            [% END %]
+        <div class="col-md-3">
+            <p>matches [% whats_this('modalhelp_match') %]</p>
         </div>
-        <div class="field-options file">
-            <h4>Document field options</h4>
-            <div class="form-group">
-                <label for="filesize">Set maximum file size (KB): (Leave blank for no limit)</label>
-                <input type="text" class="form-control" name="filesize" id="filesize"
-                    value="[% column.filesize %]" placeholder="Leave blank for no limit">
+        <div class="col-md-5 form-group">
+            <label for="display_regex">pattern</label>
+            <input type="text" class="form-control" id="display_regex" name="display_regex" value="[% column.display_regex | html_entity %]">
+    </div>
+    </div>
+    </section>
+[% END %]
+
+[% BLOCK field_type_properties %]
+    <div class="field-options tree">
+        [% IF column.id %]
+            <h4>Tree field options</h4>
+            <p>Each value in the tree is referred to as a node.</p>
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" name="end_node_only" [% IF column.end_node_only %]checked[% END %]>
+                    Only let users select an end-node
+                </label>
             </div>
-        </div>
-        <div class="field-options string">
-            <h4>Text field options</h4>
+            <h4>Tree nodes:</h4>
             <div class="form-group">
-                <div class="checkbox">
-                    <label>
-                        <input id="textbox" type="checkbox" name="textbox" [% IF column.textbox %]checked[% END %]>Make this a multi-line text box
-                    </label>
-                </div>
+                    <button class="btn btn-success btn-sm" onclick="demo_create();" type="button">Add a node</button>
+                    <button class="btn btn-warning btn-sm" onclick="demo_rename();" type="button">Rename</button>
+                    <button class="btn btn-danger btn-sm" onclick="demo_delete();" type="button">Delete</button>
+                    <button class="btn btn-info btn-sm" onclick="$('#jstree_demo_div').jstree('open_all');" type="button">Expand tree</button>
+                    <button class="btn btn-info btn-sm" onclick="$('#jstree_demo_div').jstree('close_all');" type="button">Collapse tree</button>
+                    <div id="jstree_demo_div"></div>
             </div>
+        [% ELSE %]
+            <p>Use a tree to structure the values that users can select into categories and sub-categories.</p>
+            <p>To create your tree, please save this field first, then edit it.</p>
+        [% END %]
+    </div>
+    <div class="field-options enum">
+        <h4>Dropdown field options</h4>
+        <div class="col-md-11">
             <div class="form-group">
-                <label for="force_regex">Require the field value to be in a particular format: [% whats_this('modalhelp_force_regex') %]</label>
-                <input id="force_regex" class="form-control" type="text" name="force_regex" value="[% column.force_regex | html_entity %]">
-            </div>
-        </div>
-        <div class="field-options date daterange">
-            <div class="form-group">
-                <label for="show_datepicker">Show date picker:</label>
-                <div class="checkbox">
-                    <label>
-                        <input id="show_datepicker" type="checkbox" name="show_datepicker" [% IF NOT column.show_datepicker.defined OR column.show_datepicker %]checked[% END %]>Show date picker pop-up
-                    </label>
-                </div>
-            </div>
-        </div>
-        <div class="field-options calc">
-            <p>
-                A calculated value field automatically generates values based on the values
-                of other fields. You define your calculation using the Lua programming language.
-            </p>
-            <div class="form-group">
-                <label for="return_type">Return value conversion:</label>
-                <select class="form-control" name="return_type">
-                    <option value="string" [% IF column.return_type == "string" %]selected[% END %]>String</option>
-                    <option value="date" [% IF column.return_type == "date" %]selected[% END %]>Date</option>
-                    <option value="integer" [% IF column.return_type == "integer" %]selected[% END %]>Integer</option>
-                    <option value="numeric" [% IF column.return_type == "numeric" %]selected[% END %]>Decimal</option>
+                <label for="enumval">Order dropdown values:</label>
+                <select class="form-control" name="ordering">
+                    <option value="" [% IF NOT column.ordering %]selected[% END %]>As entered</option>
+                    <option value="asc" [% IF column.ordering == "asc" %]selected[% END %]>Ascending</option>
+                    <option value="desc" [% IF column.ordering == "desc" %]selected[% END %]>Descending</option>
                 </select>
             </div>
-            <div class="form-group">
-                <label for="code_calc">Calculation: [% whats_this('helpcalc') %]</label>
-                <textarea class="form-control monospace" id="code_calc" name="code_calc" rows="10">[% column.code | html_entity %]</textarea>
-            </div>
-            <div class="form-group">
-                <label for="no_alerts_calc">Alerts:</label>
-                <div class="checkbox">
-                    <label>
-                        <input id="no_alerts_calc" type="checkbox" name="no_alerts_calc" checked>Do not send alerts when making this update
-                            (alerts will still be sent when records are subsequently edited individually)
-                    </label>
-                </div>
-            </div>
-            <div class="form-group">
-                <label for="no_cache_update">Status updates:</label>
-                <div class="radio">
-                    <label>
-                        <input type="radio" name="no_cache_update" value="0" checked>Update all existing values immediately
-                    </label>
-                </div>
-                <div class="radio">
-                    <label>
-                        <input type="radio" name="no_cache_update" value="1">Do not immediately update all existing values
-                            (values will be updated overnight instead)
-                    </label>
-                </div>
+        </div>
+        <div class="col-md-11">
+            <label for="enumval">Add dropdown values:</label>
+        </div>
+        <div id="legs">
+            [% FOREACH enumval IN column.enumvals %]
+                [% UNLESS enumval.deleted %]
+                    <div class="request-row">
+                            <div class="col-md-11">
+                                <p>
+                                <input type="text" class="form-control" name="enumval[% enumval.id %]" value="[% enumval.value | html_entity %]">
+                                </p>
+                            </div>
+                            <button type="button" class="close closeme pull-left">&times;</button>
+                    </div>
+                [% END %]
+            [% END %]
+            <div class="request-add">
+                    <div class="col-md-11">
+                        <button type="button" class="btn btn-default add">
+                            Add value
+                        </button>
+                    </div>
             </div>
         </div>
-        <div class="field-options rag">
-            <p>
-                Use a RAG field to automatically generate red, amber or green indicators based on
-                the values of other fields. You set the conditions for the RAG status using the
-                Lua programming language.
-            </p>
+    </div>
+    <div class="field-options curval">
+        <h4>Field options</h4>
+        [% IF instance_layouts.size %]
+            [% rti = column.refers_to_instance %]
             <div class="form-group">
-                <label for="code_rag">Conditions for this RAG status field: [% whats_this('helpcalc') %]</label>
-                <textarea class="form-control monospace" id="code_rag" name="code_rag" rows="10">[% column.code | html_entity %]</textarea>
+                <div class="radio">
+                    <label>
+                        <input type="radio" name="typeahead" value="0" [% IF NOT column.typeahead %]checked[% END %]>Provide values as a dropdown
+                    </label>
+                </div>
+                <div class="radio">
+                    <label>
+                        <input type="radio" name="typeahead" value="1" [% IF column.typeahead %]checked[% END %]>Provide values as an auto-complete textbox
+                    </label>
+                </div>
             </div>
             <div class="form-group">
-                <label for="no_alerts_calc">Alerts:</label>
+                <label for="override_permissions">Permissions override:</label>
                 <div class="checkbox">
                     <label>
-                        <input id="no_alerts_calc" type="checkbox" name="no_alerts_calc" checked>Do not send alerts when making this update
-                            (alerts will still be sent when records are subsequently edited individually)
+                        <input id="override_permissions" type="checkbox" name="override_permissions" [% IF column.override_permissions %]checked[% END %]>Override any user permissions when selecting records for this field
                     </label>
                 </div>
             </div>
             <div class="form-group">
-                <label for="no_cache_update">Status updates:</label>
-                <div class="radio">
-                    <label>
-                        <input type="radio" name="no_cache_update" value="0" checked>Update all existing values immediately
-                    </label>
+                <label for="refers_to_instance">Use this table:</label>
+                <select class="form-control" id="refers_to_instance" name="refers_to_instance">
+                    [% IF NOT rti %]
+                        <option></option>
+                    [% END %]
+                    [% FOREACH instance IN instance_layouts %]
+                        <option value="[% instance.instance.id %]" [% IF rti == instance.instance.id %]selected[% END %]>[% instance.instance.name | html_entity %]</option>
+                    [% END %]
+                </select>
+            </div>
+            [% FOREACH instance IN instance_layouts %]
+                <div id="instance_fields_[% instance.instance.id %]" class="instance_fields"
+                    [% IF (rti AND instance.instance.id != rti) OR NOT rti %]
+                        style="display:none"
+                    [% END %]
+                    >
+                    <div class="form-group">
+                        <label for="curval_instance">Show these fields:</label>
+                        [% FOREACH c IN instance.layout.all %]
+                            [% NEXT IF c.type == "curval" %]
+                            [% checked = "" %]
+                            [% IF instance.instance.id == rti AND column.has_curval_field(c.id) %]
+                                [% checked = "checked" %]
+                            [% END %]
+                            <div class="checkbox">
+                                <label>
+                                    <input type="checkbox" name="curval_field_ids" value="[% c.id %]" [% checked %]>[% c.name %]
+                                </label>
+                            </div>
+                        [% END %]
+                    </div>
+                    <div class="form-group">
+                            <label for="builder[% instance.layout.instance_id %]">Apply the following filters to records in the selected table::</label>
+                            <div id="builder[% instance.layout.instance_id %]"></div>
+                    </div>
                 </div>
-                <div class="radio">
-                    <label>
-                        <input type="radio" name="no_cache_update" value="1">Do not immediately update all existing values
-                            (values will be updated overnight instead)
-                    </label>
-                </div>
+            [% END %]
+            <input id="filter" type="hidden" name="filter" value="[% column.filter.as_json | html_entity %]">
+        [% ELSE %]
+            <div class="alert alert-info">
+                No other instances are available to select data from
+            </div>
+        [% END %]
+    </div>
+    <div class="field-options file">
+        <h4>Document field options</h4>
+        <div class="form-group">
+            <label for="filesize">Set maximum file size (KB): (Leave blank for no limit)</label>
+            <input type="text" class="form-control" name="filesize" id="filesize"
+                value="[% column.filesize %]" placeholder="Leave blank for no limit">
+        </div>
+    </div>
+    <div class="field-options string">
+        <h4>Text field options</h4>
+        <div class="form-group">
+            <div class="checkbox">
+                <label>
+                    <input id="textbox" type="checkbox" name="textbox" [% IF column.textbox %]checked[% END %]>Make this a multi-line text box
+                </label>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="force_regex">Require the field value to be in a particular format: [% whats_this('modalhelp_force_regex') %]</label>
+            <input id="force_regex" class="form-control" type="text" name="force_regex" value="[% column.force_regex | html_entity %]">
+        </div>
+    </div>
+    <div class="field-options date daterange">
+        <div class="form-group">
+            <label for="show_datepicker">Show date picker:</label>
+            <div class="checkbox">
+                <label>
+                    <input id="show_datepicker" type="checkbox" name="show_datepicker" [% IF NOT column.show_datepicker.defined OR column.show_datepicker %]checked[% END %]>Show date picker pop-up
+                </label>
+            </div>
+        </div>
+    </div>
+    <div class="field-options calc">
+        <h4>Calculated value field options</h4>
+        <p>
+            A calculated value field automatically generates values based on the values
+            of other fields. You define your calculation using the Lua programming language.
+        </p>
+        <div class="form-group">
+            <label for="return_type">Return value conversion:</label>
+            <select class="form-control" name="return_type">
+                <option value="string" [% IF column.return_type == "string" %]selected[% END %]>String</option>
+                <option value="date" [% IF column.return_type == "date" %]selected[% END %]>Date</option>
+                <option value="integer" [% IF column.return_type == "integer" %]selected[% END %]>Integer</option>
+                <option value="numeric" [% IF column.return_type == "numeric" %]selected[% END %]>Decimal</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="code_calc">Calculation: [% whats_this('helpcalc') %]</label>
+            <textarea class="form-control monospace" id="code_calc" name="code_calc" rows="10">[% column.code | html_entity %]</textarea>
+        </div>
+        <div class="form-group">
+            <label for="no_alerts_calc">Alerts:</label>
+            <div class="checkbox">
+                <label>
+                    <input id="no_alerts_calc" type="checkbox" name="no_alerts_calc" checked>Do not send alerts when making this update
+                        (alerts will still be sent when records are subsequently edited individually)
+                </label>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="no_cache_update">Status updates:</label>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="no_cache_update" value="0" checked>Update all existing values immediately
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="no_cache_update" value="1">Do not immediately update all existing values
+                        (values will be updated overnight instead)
+                </label>
+            </div>
+        </div>
+    </div>
+    <div class="field-options rag">
+        <h4>RAG field options</h4>
+        <p>
+            Use a RAG field to automatically generate red, amber or green indicators based on
+            the values of other fields. You set the conditions for the RAG status using the
+            Lua programming language.
+        </p>
+        <div class="form-group">
+            <label for="code_rag">Conditions for this RAG status field: [% whats_this('helpcalc') %]</label>
+            <textarea class="form-control monospace" id="code_rag" name="code_rag" rows="10">[% column.code | html_entity %]</textarea>
+        </div>
+        <div class="form-group">
+            <label for="no_alerts_calc">Alerts:</label>
+            <div class="checkbox">
+                <label>
+                    <input id="no_alerts_calc" type="checkbox" name="no_alerts_calc" checked>Do not send alerts when making this update
+                        (alerts will still be sent when records are subsequently edited individually)
+                </label>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="no_cache_update">Status updates:</label>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="no_cache_update" value="0" checked>Update all existing values immediately
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input type="radio" name="no_cache_update" value="1">Do not immediately update all existing values
+                        (values will be updated overnight instead)
+                </label>
             </div>
         </div>
     </div>
@@ -497,8 +382,7 @@
 [% BLOCK edit_field %]
     <h2>[% IF column.id %]Edit field[% ELSE %]Add a field to [% instance_name | html %][% END %]</h2>
 
-    [% PROCESS edit_field_left_column %]
-    [% PROCESS edit_field_right_column %]
+    [% PROCESS field_properties %]
 [% END %]
 
 [% BLOCK list_fields %]

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -638,6 +638,11 @@
                     }
                 });
             $(document).ready(function () {
+                $('#configure-permissions').on('click', function () {
+                    $(this).attr('hidden', '');
+                    $('#permission-configuration').removeAttr('hidden');
+                }); 
+
                 $('#sortable').sortable({
                     cancel: "a"
                 });

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -135,17 +135,17 @@
         <section id="options">
             <h3>Options</h3>
 
-            <div class="checkbox noragcalc" [% noragcalc %]>
+            <div class="checkbox stored-value">
                 <label>
                     <input type="checkbox" name="optional" [% IF column.optional %]checked[% END %]>This field is optional
                 </label>
             </div>
-            <div class="checkbox noragcalc" [% noragcalc %]>
+            <div class="checkbox stored-value">
                 <label>
                     <input type="checkbox" name="remember" [% IF column.remember %]checked[% END %]>Remember last value for new entry
                 </label>
             </div>
-            <div class="checkbox noragcalc" [% noragcalc %]>
+            <div class="checkbox stored-value">
                 <label>
                     <input type="checkbox" name="isunique" [% IF column.isunique %]checked[% END %]>The values for this field must be unique
                 </label>
@@ -252,11 +252,7 @@
 
 [% BLOCK edit_field_right_column %]
    <div class="col-md-6 col-sm-12 col-xs-12">
-        <div id="divtree"
-            [% IF column.type != "tree" %]
-                style="display:none"
-            [% END %]
-            >
+        <div class="field-options tree">
             [% IF column.id %]
                 <h4>Tree field options</h4>
                 <p>Each value in the tree is referred to as a node.</p>
@@ -280,11 +276,7 @@
                 <p>To create your tree, please save this field first, then edit it.</p>
             [% END %]
         </div>
-        <div id="divenum"
-            [% IF column.type != "enum" %]
-                style="display:none"
-            [% END %]
-            >
+        <div class="field-options enum">
             <h4>Dropdown field options</h4>
             <div class="col-md-11">
                 <div class="form-group">
@@ -321,11 +313,7 @@
                 </div>
             </div>
         </div>
-        <div id="divcurval"
-            [% IF column.type != "curval" %]
-                style="display:none"
-            [% END %]
-            >
+        <div class="field-options curval">
             <h4>Field options</h4>
             [% IF instance_layouts.size %]
                 [% rti = column.refers_to_instance %]
@@ -394,11 +382,7 @@
                 </div>
             [% END %]
         </div>
-        <div id="divfile"
-            [% IF column.type != "file" %]
-                style="display:none"
-            [% END %]
-            >
+        <div class="field-options file">
             <h4>Document field options</h4>
             <div class="form-group">
                 <label for="filesize">Set maximum file size (KB): (Leave blank for no limit)</label>
@@ -406,11 +390,7 @@
                     value="[% column.filesize %]" placeholder="Leave blank for no limit">
             </div>
         </div>
-        <div id="divstring"
-                [% IF column.type != "string" %]
-                    style="display:none"
-                [% END %]
-            >
+        <div class="field-options string">
             <h4>Text field options</h4>
             <div class="form-group">
                 <div class="checkbox">
@@ -424,11 +404,7 @@
                 <input id="force_regex" class="form-control" type="text" name="force_regex" value="[% column.force_regex | html_entity %]">
             </div>
         </div>
-        <div id="divdate"
-                [% IF column.type != "date" AND column.type != "daterange" %]
-                    style="display:none"
-                [% END %]
-            >
+        <div class="field-options date daterange">
             <div class="form-group">
                 <label for="show_datepicker">Show date picker:</label>
                 <div class="checkbox">
@@ -438,11 +414,7 @@
                 </div>
             </div>
         </div>
-        <div id="divcalc"
-            [% IF column.type != "calc" %]
-                style="display:none"
-            [% END %]
-            >
+        <div class="field-options calc">
             <p>
                 A calculated value field automatically generates values based on the values
                 of other fields. You define your calculation using the Lua programming language.
@@ -484,11 +456,7 @@
                 </div>
             </div>
         </div>
-        <div id="divrag"
-            [% IF column.type != "rag" %]
-                style="display:none"
-            [% END %]
-            >
+        <div class="field-options rag">
             <p>
                 Use a RAG field to automatically generate red, amber or green indicators based on
                 the values of other fields. You set the conditions for the RAG status using the
@@ -527,8 +495,6 @@
 
 
 [% BLOCK edit_field %]
-    [% IF column.type == "rag" OR column.type == "calc" %][% noragcalc = 'style="display:none"' %][% END %]
-
     <h2>[% IF column.id %]Edit field[% ELSE %]Add a field to [% instance_name | html %][% END %]</h2>
 
     [% PROCESS edit_field_left_column %]
@@ -723,101 +689,14 @@
                     }
                     return true;
                 });
-                $('#type').change(function(){
-                    $('#divenum').hide();
-                    $('#divtree').show();
-                    var val = $(this).val();
-                    if (val == "tree") {
-                        $('#divenum').hide();
-                        $('#divtree').show();
-                        $('#divcalc').hide();
-                        $('#divrag').hide();
-                        $('#divfile').hide();
-                        $('#divcurval').hide();
-                        $('#divstring').hide();
-                        $('#divdate').hide();
-                        $('.noragcalc').show();
-                    } else if (val == "enum") {
-                        $('#divenum').show();
-                        $('#divtree').hide();
-                        $('#divcalc').hide();
-                        $('#divrag').hide();
-                        $('#divfile').hide();
-                        $('#divcurval').hide();
-                        $('#divstring').hide();
-                        $('#divdate').hide();
-                        $('.noragcalc').show();
-                    } else if (val == "rag") {
-                        $('#divrag').show();
-                        $('#divtree').hide();
-                        $('#divenum').hide();
-                        $('#divcalc').hide();
-                        $('#divfile').hide();
-                        $('#divcurval').hide();
-                        $('#divstring').hide();
-                        $('#divdate').hide();
-                        $('.noragcalc').hide();
-                    } else if (val == "calc") {
-                        $('#divrag').hide();
-                        $('#divtree').hide();
-                        $('#divenum').hide();
-                        $('#divcalc').show();
-                        $('#divfile').hide();
-                        $('#divcurval').hide();
-                        $('#divstring').hide();
-                        $('#divdate').hide();
-                        $('.noragcalc').hide();
-                    } else if (val == "file") {
-                        $('#divcalc').hide();
-                        $('#divrag').hide();
-                        $('#divtree').hide();
-                        $('#divenum').hide();
-                        $('#divfile').show();
-                        $('#divcurval').hide();
-                        $('#divstring').hide();
-                        $('#divdate').hide();
-                        $('.noragcalc').show();
-                    } else if (val == "curval") {
-                        $('#divcalc').hide();
-                        $('#divrag').hide();
-                        $('#divtree').hide();
-                        $('#divenum').hide();
-                        $('#divfile').hide();
-                        $('#divcurval').show();
-                        $('#divstring').hide();
-                        $('#divdate').hide();
-                        $('.noragcalc').show();
-                    } else if (val == "string") {
-                        $('#divcalc').hide();
-                        $('#divrag').hide();
-                        $('#divtree').hide();
-                        $('#divenum').hide();
-                        $('#divfile').hide();
-                        $('#divcurval').hide();
-                        $('#divstring').show();
-                        $('#divdate').hide();
-                        $('.noragcalc').show();
-                    } else if (val == "date" || val == "daterange") {
-                        $('#divcalc').hide();
-                        $('#divrag').hide();
-                        $('#divtree').hide();
-                        $('#divenum').hide();
-                        $('#divfile').hide();
-                        $('#divcurval').hide();
-                        $('#divstring').hide();
-                        $('#divdate').show();
-                        $('.noragcalc').show();
-                    } else {
-                        $('#divenum').hide();
-                        $('#divtree').hide();
-                        $('#divcalc').hide();
-                        $('#divrag').hide();
-                        $('#divfile').hide();
-                        $('#divcurval').hide();
-                        $('#divstring').hide();
-                        $('#divdate').hide();
-                        $('.noragcalc').show();
-                    }
+
+                $('#type').on('change', function () {
+                    var $mf = $('#manage-fields');
+                    var current_type = $mf.data('column-type');
+                    var new_type = $(this).val();
+                    $mf.removeClass('column-type-' + current_type);
+                    $mf.addClass('column-type-' + new_type);
+                    $mf.data('column-type', new_type);
                 });
             }); 
     [% END %]
@@ -830,7 +709,7 @@
     <input type="hidden" name="id" value="[% column.id %]">
 [% END %]
 
-    <section class="manage-fields row">
+    <section id="manage-fields" data-column-type="[% column.id ? column.type : 'string' %]" class="row column-type-[% column.id ? column.type : 'string' %]">
         [% 
             IF column.defined;
                 PROCESS edit_field;

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -167,7 +167,6 @@
     </div>
     <div class="field-options enum">
         <h4>Dropdown field options</h4>
-        <div class="col-md-11">
             <div class="form-group">
                 <label for="enumval">Order dropdown values:</label>
                 <select class="form-control" name="ordering">
@@ -176,25 +175,20 @@
                     <option value="desc" [% IF column.ordering == "desc" %]selected[% END %]>Descending</option>
                 </select>
             </div>
-        </div>
-        <div class="col-md-11">
+        <div>
             <label for="enumval">Add dropdown values:</label>
         </div>
         <div id="legs">
             [% FOREACH enumval IN column.enumvals %]
                 [% UNLESS enumval.deleted %]
                     <div class="request-row">
-                            <div class="col-md-11">
-                                <p>
-                                <input type="text" class="form-control" name="enumval[% enumval.id %]" value="[% enumval.value | html_entity %]">
-                                </p>
-                            </div>
-                            <button type="button" class="close closeme pull-left">&times;</button>
+                        <input type="text" class="form-control" name="enumval[% enumval.id %]" value="[% enumval.value | html_entity %]">
+                        <button type="button" class="close closeme">&times;</button>
                     </div>
                 [% END %]
             [% END %]
             <div class="request-add">
-                    <div class="col-md-11">
+                    <div class="">
                         <button type="button" class="btn btn-default add">
                             Add value
                         </button>

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -494,12 +494,6 @@
                     }
                 });
             $(document).ready(function () {
-                $('#configure-permissions').on('click', function () {
-                    $(this).attr('hidden', '');
-                    $('#permission-configuration').removeAttr('hidden');
-                    $(this).parent().find('h4').focus();
-                }); 
-
                 $('#sortable').sortable({
                     cancel: "a"
                 });

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -1,963 +1,826 @@
 [% PROCESS help.tt %]
 [% PROCESS snippets/util.tt %]
+[% PROCESS snippets/layout_permissions.tt %]
 
-<div class="manage-fields">
-
-[% IF column.defined %]
-<h2>[% IF column.id %]Edit field[% ELSE %]Add a field to [% instance_name | html %][% END %]</h2>
-
-<form role="form" method="post">
-    <div class="row">
-        <div class="col-md-6">
-            [% IF column.id %]
-                <input type="hidden" name="id" value="[% column.id %]">
-            [% END %]
-            [% IF column.type == "rag" OR column.type == "calc" %][% noragcalc = 'style="display:none"' %][% END %]
-            <div class="form-group">
-                <label for="name">Field name:</label>
-                <input type="text" class="form-control" id="name" name="name" value="[% column.name | html_entity %]">
-            </div>
-            [% UNLESS column.id %]
-                <div class="form-group">
-                    <label for="type">Type:</label>
-                    <select class="form-control" id="type" name="type">
-                        <option value="string" [% IF column.type == "string" %]selected[% END %]>Text</option>
-                        <option value="intgr" [% IF column.type == "intgr" %]selected[% END %]>Integer</option>
-                        <option value="date" [% IF column.type == "date" %]selected[% END %]>Date</option>
-                        <option value="daterange" [% IF column.type == "daterange" %]selected[% END %]>Date range</option>
-                        <option value="enum" [% IF column.type == "enum" %]selected[% END %]>Dropdown list</option>
-                        <option value="tree" [% IF column.type == "tree" %]selected[% END %]>Tree</option>
-                        <option value="file" [% IF column.type == "file" %]selected[% END %]>Document</option>
-                        <option value="person" [% IF column.type == "person" %]selected[% END %]>Person</option>
-                        <option value="rag" [% IF column.type == "rag" %]selected[% END %]>RedAmberGreen status (RAG)</option>
-                        <option value="calc" [% IF column.type == "calc" %]selected[% END %]>Calculated value</option>
-                        <option value="curval" [% IF column.type == "curval" %]selected[% END %]>Field(s) for records from another table</option>
-                    </select>
+[% BLOCK layout_modals %]
+    <div class="modal fade" id="helprag" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">RAG values</h4>
                 </div>
-            [% END %]
-            <div class="form-group">
-                <label for="description">Description:</label>
-                <input type="text" class="form-control" id="description" name="description" value="[% column.description | html_entity %]">
-            </div>
-            <div class="form-group">
-                <label for="name_short"><span style="font-weight:normal">Short name: [% whats_this('modalhelp_name_short') %]</span></label>
-                <input type="text" class="form-control" id="name_short" name="name_short" value="[% column.name_short | html_entity %]">
-            </div>
-            <div class="form-group">
-                <label for="link_parent_id">Link to a field in another table:</label>
-                [% IF instance_layouts.size %]
-                    <select class="form-control" id="link_parent_id" name="link_parent_id">
-                        <option value="">&lt;Not linked&gt;</option>
-                        [% FOREACH l IN instance_layouts %]
-                            [% FOREACH c IN l.layout.all %]
-                                <option value="[% c.id %]" [% IF column.link_parent.id == c.id %]selected[% END %]>[% l.instance.name %] - [% c.name %]</option>
-                            [% END %]
-                        [% END %]
-                    </select>
-                [% ELSE %]
-                    <select class="form-control" id="link_parent_id" name="link_parent_id" disabled readonly>
-                        <option value="">&lt;No other datasheets exist&gt;</option>
-                    </select>
+                <div class="modal-body">
+                    <p>[% global.helptext.layout_rag %]</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+
+    <!-- Modal -->
+    <div class="modal fade" id="helpcalc" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Calculated and RAG values</h4>
+                </div>
+                <div class="modal-body">
+                    <p>[% global.helptext.layout_calc %]</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+   <!-- Modal -->
+    <div class="modal fade" id="modalhelp_match" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Matching field values</h4>
+                </div>
+                <div class="modal-body">
+                    <p>[% global.helptext.layout_match %]</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+
+    <!-- Modal -->
+    <div class="modal fade" id="modalhelp_name_short" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Field short names</h4>
+                </div>
+                <div class="modal-body">
+                    <p>[% global.helptext.name_short %]</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+   <!-- Modal -->
+
+    <div class="modal fade" id="modalhelp_groups" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Permissions</h4>
+                </div>
+                <div class="modal-body">
+                    <p>[% global.helptext.layout_groups %]</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+   <!-- Modal -->
+
+    <div class="modal fade" id="modalhelp_force_regex" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Force input format</h4>
+                </div>
+                <div class="modal-body">
+                    <p>[% global.helptext.force_regex %]</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+   <!-- Modal -->
+    <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <form role="form" method="post" enctype="multipart/form-data">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Are you sure?</h4>
+                </div>
+                <div class="modal-body">
+                    <p>Are you sure you want to delete this item? Deleting an item will also delete all its associated data.</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" name="delete" value="delete" class="btn btn-primary">Confirm deletion</button>
+                </div>
+                </form>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+[% END %]
+
+[% BLOCK edit_field %]
+    <h2>[% IF column.id %]Edit field[% ELSE %]Add a field to [% instance_name | html %][% END %]</h2>
+
+    <form role="form" method="post">
+        <div class="row">
+            <div class="col-md-6">
+                [% IF column.id %]
+                    <input type="hidden" name="id" value="[% column.id %]">
                 [% END %]
-            </div>
-            <div class="form-group">
-                <label for="helptext">Help text for the user:</label>
-                <textarea class="form-control" rows="5" id="helptext" name="helptext">[% column.helptext | html_entity %]</textarea>
-            </div>
-            <div class="checkbox noragcalc" [% noragcalc %]>
-                <label>
-                    <input type="checkbox" name="optional" [% IF column.optional %]checked[% END %]>This field is optional
-                </label>
-            </div>
-            <div class="checkbox noragcalc" [% noragcalc %]>
-                <label>
-                    <input type="checkbox" name="remember" [% IF column.remember %]checked[% END %]>Remember last value for new entry
-                </label>
-            </div>
-            <div class="checkbox noragcalc" [% noragcalc %]>
-                <label>
-                    <input type="checkbox" name="isunique" [% IF column.isunique %]checked[% END %]>The values for this field must be unique
-                </label>
-            </div>
-            [% IF column.can_multivalue %]
-                <div class="checkbox">
+                [% IF column.type == "rag" OR column.type == "calc" %][% noragcalc = 'style="display:none"' %][% END %]
+                <div class="form-group">
+                    <label for="name">Field name:</label>
+                    <input type="text" class="form-control" id="name" name="name" value="[% column.name | html_entity %]">
+                </div>
+                [% UNLESS column.id %]
+                    <div class="form-group">
+                        <label for="type">Type:</label>
+                        <select class="form-control" id="type" name="type">
+                            <option value="string" [% IF column.type == "string" %]selected[% END %]>Text</option>
+                            <option value="intgr" [% IF column.type == "intgr" %]selected[% END %]>Integer</option>
+                            <option value="date" [% IF column.type == "date" %]selected[% END %]>Date</option>
+                            <option value="daterange" [% IF column.type == "daterange" %]selected[% END %]>Date range</option>
+                            <option value="enum" [% IF column.type == "enum" %]selected[% END %]>Dropdown list</option>
+                            <option value="tree" [% IF column.type == "tree" %]selected[% END %]>Tree</option>
+                            <option value="file" [% IF column.type == "file" %]selected[% END %]>Document</option>
+                            <option value="person" [% IF column.type == "person" %]selected[% END %]>Person</option>
+                            <option value="rag" [% IF column.type == "rag" %]selected[% END %]>RedAmberGreen status (RAG)</option>
+                            <option value="calc" [% IF column.type == "calc" %]selected[% END %]>Calculated value</option>
+                            <option value="curval" [% IF column.type == "curval" %]selected[% END %]>Field(s) for records from another table</option>
+                        </select>
+                    </div>
+                [% END %]
+                <div class="form-group">
+                    <label for="description">Description:</label>
+                    <input type="text" class="form-control" id="description" name="description" value="[% column.description | html_entity %]">
+                </div>
+                <div class="form-group">
+                    <label for="name_short"><span style="font-weight:normal">Short name: [% whats_this('modalhelp_name_short') %]</span></label>
+                    <input type="text" class="form-control" id="name_short" name="name_short" value="[% column.name_short | html_entity %]">
+                </div>
+                <div class="form-group">
+                    <label for="link_parent_id">Link to a field in another table:</label>
+                    [% IF instance_layouts.size %]
+                        <select class="form-control" id="link_parent_id" name="link_parent_id">
+                            <option value="">&lt;Not linked&gt;</option>
+                            [% FOREACH l IN instance_layouts %]
+                                [% FOREACH c IN l.layout.all %]
+                                    <option value="[% c.id %]" [% IF column.link_parent.id == c.id %]selected[% END %]>[% l.instance.name %] - [% c.name %]</option>
+                                [% END %]
+                            [% END %]
+                        </select>
+                    [% ELSE %]
+                        <select class="form-control" id="link_parent_id" name="link_parent_id" disabled readonly>
+                            <option value="">&lt;No other datasheets exist&gt;</option>
+                        </select>
+                    [% END %]
+                </div>
+                <div class="form-group">
+                    <label for="helptext">Help text for the user:</label>
+                    <textarea class="form-control" rows="5" id="helptext" name="helptext">[% column.helptext | html_entity %]</textarea>
+                </div>
+                <div class="checkbox noragcalc" [% noragcalc %]>
                     <label>
-                        <input type="checkbox" name="multivalue" [% IF column.multivalue %]checked[% END %]>Allow multiple values
+                        <input type="checkbox" name="optional" [% IF column.optional %]checked[% END %]>This field is optional
                     </label>
                 </div>
-            [% END %]
-            <div class="checkbox noragcalc" [% noragcalc %]>
-                <label>
-                    <input type="checkbox" id="display_condition" name="display_condition" [% IF column.display_field %]checked[% END %]>Only display this field under the following conditions:
-                </label>
-            </div>
-            <div class="form-group" id="display_condition_div" [% UNLESS column.display_field %]style="display:none"[% END %]>
-                <div class="row">
-                    <div class="col-md-5">
-                        <select class="form-control" id="display_field" name="display_field">
-                            [% FOREACH field in all_columns %]
-                                <option value="[% field.id %]" [% IF column.display_field == field.id %]selected[% END %]>[% field.name | html_entity %]</option>
-                            [% END %]
-                        </select>
-                    </div>
-                    <div class="col-md-2">
-                        <p>matches [% whats_this('modalhelp_match') %]</p>
-                    </div>
-                    <div class="col-md-5">
-                        <div class="form-group">
-                            <input type="text" class="form-control" id="display_regex" name="display_regex" value="[% column.display_regex | html_entity %]">
-                        </div>
-                    </div>
+                <div class="checkbox noragcalc" [% noragcalc %]>
+                    <label>
+                        <input type="checkbox" name="remember" [% IF column.remember %]checked[% END %]>Remember last value for new entry
+                    </label>
                 </div>
-            </div>
-            <hr>
-            <h3>Permissions [% whats_this('modalhelp_groups') %]</h3>
-                [% IF column.id %]
-                    [% IF NOT column.permissions.size %]
-                        <p>Access must be granted to this field before anyone (including you) can view and edit data in it.</p>
-                        [% IF groups.all.size %]
-                            <p>To give access, a group must be assigned to it using the buttons below:</p>
-                        [% ELSE %]
-                            <p>Groups are used to assign access. You must first <a href="/group">create a group</a></p>
-                        [% END %]
-                    [% END %]
-
-                    [% IF groups.all.size %]
-                        <button type="button" aria-haspopup="true" class="btn btn-default" data-toggle="modal" data-target="#modal_access_control">Configure access</button>
-                        <button type="button" aria-haspopup="true" class="btn btn-default" data-toggle="modal" data-target="#modal_approval_control">Configure approval</button>
-                    [% END %]
-
-                    [% IF column.permissions.size %]
-                    <section class="permissions">
-                        <h4>Groups that can read:</h4>
-                        <ul>
-                            [% FOREACH g IN column.group_summary('read') %]
-                            <li>[% g %]</li>
-                            [% END %]
-                        </ul>
-
-                        <h4>Groups that can write new values:</h4>
-                        <ul>
-                            [% FOREACH g IN column.group_summary('write_new') %]
-                            <li>[% g %]</li>
-                            [% END %]
-                        </ul>
-
-                        <h4>Groups that can write existing values:</h4>
-                        <ul>
-                            [% FOREACH g IN column.group_summary('write_existing') %]
-                            <li>[% g %]</li>
-                            [% END %]
-                        </ul>
-                    </sections>
-                    [% END %]
-                [% ELSE %]
-                    <p>Please save the field before adding permissions</p>
-                [% END %]
-        </div>
-        <div class="col-md-6">
-            <div id="divtree"
-                [% IF column.type != "tree" %]
-                    style="display:none"
-                [% END %]
-                >
-                [% IF column.id %]
-                    <h4>Tree field options</h4>
-                    <p>Each value in the tree is referred to as a node.</p>
+                <div class="checkbox noragcalc" [% noragcalc %]>
+                    <label>
+                        <input type="checkbox" name="isunique" [% IF column.isunique %]checked[% END %]>The values for this field must be unique
+                    </label>
+                </div>
+                [% IF column.can_multivalue %]
                     <div class="checkbox">
                         <label>
-                            <input type="checkbox" name="end_node_only" [% IF column.end_node_only %]checked[% END %]>
-                            Only let users select an end-node
+                            <input type="checkbox" name="multivalue" [% IF column.multivalue %]checked[% END %]>Allow multiple values
                         </label>
                     </div>
-                    <h4>Tree nodes:</h4>
-                    <div class="form-group">
-                            <button class="btn btn-success btn-sm" onclick="demo_create();" type="button">Add a node</button>
-                            <button class="btn btn-warning btn-sm" onclick="demo_rename();" type="button">Rename</button>
-                            <button class="btn btn-danger btn-sm" onclick="demo_delete();" type="button">Delete</button>
-                            <button class="btn btn-info btn-sm" onclick="$('#jstree_demo_div').jstree('open_all');" type="button">Expand tree</button>
-                            <button class="btn btn-info btn-sm" onclick="$('#jstree_demo_div').jstree('close_all');" type="button">Collapse tree</button>
-                            <div id="jstree_demo_div"></div>
-                    </div>
-                [% ELSE %]
-                    <p>Use a tree to structure the values that users can select into categories and sub-categories.</p>
-                    <p>To create your tree, please save this field first, then edit it.</p>
                 [% END %]
-            </div>
-            <div id="divenum"
-                [% IF column.type != "enum" %]
-                    style="display:none"
-                [% END %]
-                >
-                <h4>Dropdown field options</h4>
-                <div class="col-md-11">
-                    <div class="form-group">
-                        <label for="enumval">Order dropdown values:</label>
-                        <select class="form-control" name="ordering">
-                            <option value="" [% IF NOT column.ordering %]selected[% END %]>As entered</option>
-                            <option value="asc" [% IF column.ordering == "asc" %]selected[% END %]>Ascending</option>
-                            <option value="desc" [% IF column.ordering == "desc" %]selected[% END %]>Descending</option>
-                        </select>
-                    </div>
+                <div class="checkbox noragcalc" [% noragcalc %]>
+                    <label>
+                        <input type="checkbox" id="display_condition" name="display_condition" [% IF column.display_field %]checked[% END %]>Only display this field under the following conditions:
+                    </label>
                 </div>
-                <div class="col-md-11">
-                    <label for="enumval">Add dropdown values:</label>
-                </div>
-                <div id="legs">
-                    [% FOREACH enumval IN column.enumvals %]
-                        [% UNLESS enumval.deleted %]
-                            <div class="request-row">
-                                    <div class="col-md-11">
-                                        <p>
-                                        <input type="text" class="form-control" name="enumval[% enumval.id %]" value="[% enumval.value | html_entity %]">
-                                        </p>
-                                    </div>
-                                    <button type="button" class="close closeme pull-left">&times;</button>
+                <div class="form-group" id="display_condition_div" [% UNLESS column.display_field %]style="display:none"[% END %]>
+                    <div class="row">
+                        <div class="col-md-5">
+                            <select class="form-control" id="display_field" name="display_field">
+                                [% FOREACH field in all_columns %]
+                                    <option value="[% field.id %]" [% IF column.display_field == field.id %]selected[% END %]>[% field.name | html_entity %]</option>
+                                [% END %]
+                            </select>
+                        </div>
+                        <div class="col-md-2">
+                            <p>matches [% whats_this('modalhelp_match') %]</p>
+                        </div>
+                        <div class="col-md-5">
+                            <div class="form-group">
+                                <input type="text" class="form-control" id="display_regex" name="display_regex" value="[% column.display_regex | html_entity %]">
                             </div>
-                        [% END %]
+                        </div>
+                    </div>
+                </div>
+                <hr>
+            </div>
+            <div class="col-md-6">
+                <div id="divtree"
+                    [% IF column.type != "tree" %]
+                        style="display:none"
                     [% END %]
-                    <div class="request-add">
-                            <div class="col-md-11">
-                                <button type="button" class="btn btn-default add">
-                                    Add
-                                </button>
-                            </div>
-                    </div>
-                </div>
-            </div>
-            <div id="divcurval"
-                [% IF column.type != "curval" %]
-                    style="display:none"
-                [% END %]
-                >
-                <h4>Field options</h4>
-                [% IF instance_layouts.size %]
-                    [% rti = column.refers_to_instance %]
-                    <div class="form-group">
-                        <div class="radio">
-                            <label>
-                                <input type="radio" name="typeahead" value="0" [% IF NOT column.typeahead %]checked[% END %]>Provide values as a dropdown
-                            </label>
-                        </div>
-                        <div class="radio">
-                            <label>
-                                <input type="radio" name="typeahead" value="1" [% IF column.typeahead %]checked[% END %]>Provide values as an auto-complete textbox
-                            </label>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label for="override_permissions">Permissions override:</label>
+                    >
+                    [% IF column.id %]
+                        <h4>Tree field options</h4>
+                        <p>Each value in the tree is referred to as a node.</p>
                         <div class="checkbox">
                             <label>
-                                <input id="override_permissions" type="checkbox" name="override_permissions" [% IF column.override_permissions %]checked[% END %]>Override any user permissions when selecting records for this field
+                                <input type="checkbox" name="end_node_only" [% IF column.end_node_only %]checked[% END %]>
+                                Only let users select an end-node
+                            </label>
+                        </div>
+                        <h4>Tree nodes:</h4>
+                        <div class="form-group">
+                                <button class="btn btn-success btn-sm" onclick="demo_create();" type="button">Add a node</button>
+                                <button class="btn btn-warning btn-sm" onclick="demo_rename();" type="button">Rename</button>
+                                <button class="btn btn-danger btn-sm" onclick="demo_delete();" type="button">Delete</button>
+                                <button class="btn btn-info btn-sm" onclick="$('#jstree_demo_div').jstree('open_all');" type="button">Expand tree</button>
+                                <button class="btn btn-info btn-sm" onclick="$('#jstree_demo_div').jstree('close_all');" type="button">Collapse tree</button>
+                                <div id="jstree_demo_div"></div>
+                        </div>
+                    [% ELSE %]
+                        <p>Use a tree to structure the values that users can select into categories and sub-categories.</p>
+                        <p>To create your tree, please save this field first, then edit it.</p>
+                    [% END %]
+                </div>
+                <div id="divenum"
+                    [% IF column.type != "enum" %]
+                        style="display:none"
+                    [% END %]
+                    >
+                    <h4>Dropdown field options</h4>
+                    <div class="col-md-11">
+                        <div class="form-group">
+                            <label for="enumval">Order dropdown values:</label>
+                            <select class="form-control" name="ordering">
+                                <option value="" [% IF NOT column.ordering %]selected[% END %]>As entered</option>
+                                <option value="asc" [% IF column.ordering == "asc" %]selected[% END %]>Ascending</option>
+                                <option value="desc" [% IF column.ordering == "desc" %]selected[% END %]>Descending</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="col-md-11">
+                        <label for="enumval">Add dropdown values:</label>
+                    </div>
+                    <div id="legs">
+                        [% FOREACH enumval IN column.enumvals %]
+                            [% UNLESS enumval.deleted %]
+                                <div class="request-row">
+                                        <div class="col-md-11">
+                                            <p>
+                                            <input type="text" class="form-control" name="enumval[% enumval.id %]" value="[% enumval.value | html_entity %]">
+                                            </p>
+                                        </div>
+                                        <button type="button" class="close closeme pull-left">&times;</button>
+                                </div>
+                            [% END %]
+                        [% END %]
+                        <div class="request-add">
+                                <div class="col-md-11">
+                                    <button type="button" class="btn btn-default add">
+                                        Add
+                                    </button>
+                                </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="divcurval"
+                    [% IF column.type != "curval" %]
+                        style="display:none"
+                    [% END %]
+                    >
+                    <h4>Field options</h4>
+                    [% IF instance_layouts.size %]
+                        [% rti = column.refers_to_instance %]
+                        <div class="form-group">
+                            <div class="radio">
+                                <label>
+                                    <input type="radio" name="typeahead" value="0" [% IF NOT column.typeahead %]checked[% END %]>Provide values as a dropdown
+                                </label>
+                            </div>
+                            <div class="radio">
+                                <label>
+                                    <input type="radio" name="typeahead" value="1" [% IF column.typeahead %]checked[% END %]>Provide values as an auto-complete textbox
+                                </label>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label for="override_permissions">Permissions override:</label>
+                            <div class="checkbox">
+                                <label>
+                                    <input id="override_permissions" type="checkbox" name="override_permissions" [% IF column.override_permissions %]checked[% END %]>Override any user permissions when selecting records for this field
+                                </label>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label for="refers_to_instance">Use this table:</label>
+                            <select class="form-control" id="refers_to_instance" name="refers_to_instance">
+                                [% IF NOT rti %]
+                                    <option></option>
+                                [% END %]
+                                [% FOREACH instance IN instance_layouts %]
+                                    <option value="[% instance.instance.id %]" [% IF rti == instance.instance.id %]selected[% END %]>[% instance.instance.name | html_entity %]</option>
+                                [% END %]
+                            </select>
+                        </div>
+                        [% FOREACH instance IN instance_layouts %]
+                            <div id="instance_fields_[% instance.instance.id %]" class="instance_fields"
+                                [% IF (rti AND instance.instance.id != rti) OR NOT rti %]
+                                    style="display:none"
+                                [% END %]
+                                >
+                                <div class="form-group">
+                                    <label for="curval_instance">Show these fields:</label>
+                                    [% FOREACH c IN instance.layout.all %]
+                                        [% NEXT IF c.type == "curval" %]
+                                        [% checked = "" %]
+                                        [% IF instance.instance.id == rti AND column.has_curval_field(c.id) %]
+                                            [% checked = "checked" %]
+                                        [% END %]
+                                        <div class="checkbox">
+                                            <label>
+                                                <input type="checkbox" name="curval_field_ids" value="[% c.id %]" [% checked %]>[% c.name %]
+                                            </label>
+                                        </div>
+                                    [% END %]
+                                </div>
+                                <div class="form-group">
+                                        <label for="builder[% instance.layout.instance_id %]">Apply the following filters to records in the selected table::</label>
+                                        <div id="builder[% instance.layout.instance_id %]"></div>
+                                </div>
+                            </div>
+                        [% END %]
+                        <input id="filter" type="hidden" name="filter" value="[% column.filter.as_json | html_entity %]">
+                    [% ELSE %]
+                        <div class="alert alert-info">
+                            No other instances are available to select data from
+                        </div>
+                    [% END %]
+                </div>
+                <div id="divfile"
+                    [% IF column.type != "file" %]
+                        style="display:none"
+                    [% END %]
+                    >
+                    <h4>Document field options</h4>
+                    <div class="form-group">
+                        <label for="filesize">Set maximum file size (KB): (Leave blank for no limit)</label>
+                        <input type="text" class="form-control" name="filesize" id="filesize"
+                            value="[% column.filesize %]" placeholder="Leave blank for no limit">
+                    </div>
+                </div>
+                <div id="divstring"
+                        [% IF column.type != "string" %]
+                            style="display:none"
+                        [% END %]
+                    >
+                    <h4>Text field options</h4>
+                    <div class="form-group">
+                        <div class="checkbox">
+                            <label>
+                                <input id="textbox" type="checkbox" name="textbox" [% IF column.textbox %]checked[% END %]>Make this a multi-line text box
                             </label>
                         </div>
                     </div>
                     <div class="form-group">
-                        <label for="refers_to_instance">Use this table:</label>
-                        <select class="form-control" id="refers_to_instance" name="refers_to_instance">
-                            [% IF NOT rti %]
-                                <option></option>
-                            [% END %]
-                            [% FOREACH instance IN instance_layouts %]
-                                <option value="[% instance.instance.id %]" [% IF rti == instance.instance.id %]selected[% END %]>[% instance.instance.name | html_entity %]</option>
-                            [% END %]
+                        <label for="force_regex">Require the field value to be in a particular format: [% whats_this('modalhelp_force_regex') %]</label>
+                        <input id="force_regex" class="form-control" type="text" name="force_regex" value="[% column.force_regex | html_entity %]">
+                    </div>
+                </div>
+                <div id="divdate"
+                        [% IF column.type != "date" AND column.type != "daterange" %]
+                            style="display:none"
+                        [% END %]
+                    >
+                    <div class="form-group">
+                        <label for="show_datepicker">Show date picker:</label>
+                        <div class="checkbox">
+                            <label>
+                                <input id="show_datepicker" type="checkbox" name="show_datepicker" [% IF NOT column.show_datepicker.defined OR column.show_datepicker %]checked[% END %]>Show date picker pop-up
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div id="divcalc"
+                    [% IF column.type != "calc" %]
+                        style="display:none"
+                    [% END %]
+                    >
+                    <p>
+                        A calculated value field automatically generates values based on the values
+                        of other fields. You define your calculation using the Lua programming language.
+                    </p>
+                    <div class="form-group">
+                        <label for="return_type">Return value conversion:</label>
+                        <select class="form-control" name="return_type">
+                            <option value="string" [% IF column.return_type == "string" %]selected[% END %]>String</option>
+                            <option value="date" [% IF column.return_type == "date" %]selected[% END %]>Date</option>
+                            <option value="integer" [% IF column.return_type == "integer" %]selected[% END %]>Integer</option>
+                            <option value="numeric" [% IF column.return_type == "numeric" %]selected[% END %]>Decimal</option>
                         </select>
                     </div>
-                    [% FOREACH instance IN instance_layouts %]
-                        <div id="instance_fields_[% instance.instance.id %]" class="instance_fields"
-                            [% IF (rti AND instance.instance.id != rti) OR NOT rti %]
-                                style="display:none"
-                            [% END %]
-                            >
-                            <div class="form-group">
-                                <label for="curval_instance">Show these fields:</label>
-                                [% FOREACH c IN instance.layout.all %]
-                                    [% NEXT IF c.type == "curval" %]
-                                    [% checked = "" %]
-                                    [% IF instance.instance.id == rti AND column.has_curval_field(c.id) %]
-                                        [% checked = "checked" %]
-                                    [% END %]
-                                    <div class="checkbox">
-                                        <label>
-                                            <input type="checkbox" name="curval_field_ids" value="[% c.id %]" [% checked %]>[% c.name %]
-                                        </label>
-                                    </div>
-                                [% END %]
-                            </div>
-                            <div class="form-group">
-                                    <label for="builder[% instance.layout.instance_id %]">Apply the following filters to records in the selected table::</label>
-                                    <div id="builder[% instance.layout.instance_id %]"></div>
-                            </div>
+                    <div class="form-group">
+                        <label for="code_calc">Calculation: [% whats_this('helpcalc') %]</label>
+                        <textarea class="form-control monospace" id="code_calc" name="code_calc" rows="10">[% column.code | html_entity %]</textarea>
+                    </div>
+                    <div class="form-group">
+                        <label for="no_alerts_calc">Alerts:</label>
+                        <div class="checkbox">
+                            <label>
+                                <input id="no_alerts_calc" type="checkbox" name="no_alerts_calc" checked>Do not send alerts when making this update
+                                    (alerts will still be sent when records are subsequently edited individually)
+                            </label>
                         </div>
-                    [% END %]
-                    <input id="filter" type="hidden" name="filter" value="[% column.filter.as_json | html_entity %]">
-                [% ELSE %]
-                    <div class="alert alert-info">
-                        No other instances are available to select data from
                     </div>
-                [% END %]
-            </div>
-            <div id="divfile"
-                [% IF column.type != "file" %]
-                    style="display:none"
-                [% END %]
-                >
-                <h4>Document field options</h4>
-                <div class="form-group">
-                    <label for="filesize">Set maximum file size (KB): (Leave blank for no limit)</label>
-                    <input type="text" class="form-control" name="filesize" id="filesize"
-                        value="[% column.filesize %]" placeholder="Leave blank for no limit">
+                    <div class="form-group">
+                        <label for="no_cache_update">Status updates:</label>
+                        <div class="radio">
+                            <label>
+                                <input type="radio" name="no_cache_update" value="0" checked>Update all existing values immediately
+                            </label>
+                        </div>
+                        <div class="radio">
+                            <label>
+                                <input type="radio" name="no_cache_update" value="1">Do not immediately update all existing values
+                                    (values will be updated overnight instead)
+                            </label>
+                        </div>
+                    </div>
                 </div>
-            </div>
-            <div id="divstring"
-                    [% IF column.type != "string" %]
+                <div id="divrag"
+                    [% IF column.type != "rag" %]
                         style="display:none"
                     [% END %]
-                >
-                <h4>Text field options</h4>
-                <div class="form-group">
-                    <div class="checkbox">
-                        <label>
-                            <input id="textbox" type="checkbox" name="textbox" [% IF column.textbox %]checked[% END %]>Make this a multi-line text box
-                        </label>
+                    >
+                    <p>
+                        Use a RAG field to automatically generate red, amber or green indicators based on
+                        the values of other fields. You set the conditions for the RAG status using the
+                        Lua programming language.
+                    </p>
+                    <div class="form-group">
+                        <label for="code_rag">Conditions for this RAG status field: [% whats_this('helpcalc') %]</label>
+                        <textarea class="form-control monospace" id="code_rag" name="code_rag" rows="10">[% column.code | html_entity %]</textarea>
                     </div>
-                </div>
-                <div class="form-group">
-                    <label for="force_regex">Require the field value to be in a particular format: [% whats_this('modalhelp_force_regex') %]</label>
-                    <input id="force_regex" class="form-control" type="text" name="force_regex" value="[% column.force_regex | html_entity %]">
-                </div>
-            </div>
-            <div id="divdate"
-                    [% IF column.type != "date" AND column.type != "daterange" %]
-                        style="display:none"
-                    [% END %]
-                >
-                <div class="form-group">
-                    <label for="show_datepicker">Show date picker:</label>
-                    <div class="checkbox">
-                        <label>
-                            <input id="show_datepicker" type="checkbox" name="show_datepicker" [% IF NOT column.show_datepicker.defined OR column.show_datepicker %]checked[% END %]>Show date picker pop-up
-                        </label>
+                    <div class="form-group">
+                        <label for="no_alerts_calc">Alerts:</label>
+                        <div class="checkbox">
+                            <label>
+                                <input id="no_alerts_calc" type="checkbox" name="no_alerts_calc" checked>Do not send alerts when making this update
+                                    (alerts will still be sent when records are subsequently edited individually)
+                            </label>
+                        </div>
                     </div>
-                </div>
-            </div>
-            <div id="divcalc"
-                [% IF column.type != "calc" %]
-                    style="display:none"
-                [% END %]
-                >
-                <p>
-                    A calculated value field automatically generates values based on the values
-                    of other fields. You define your calculation using the Lua programming language.
-                </p>
-                <div class="form-group">
-                    <label for="return_type">Return value conversion:</label>
-                    <select class="form-control" name="return_type">
-                        <option value="string" [% IF column.return_type == "string" %]selected[% END %]>String</option>
-                        <option value="date" [% IF column.return_type == "date" %]selected[% END %]>Date</option>
-                        <option value="integer" [% IF column.return_type == "integer" %]selected[% END %]>Integer</option>
-                        <option value="numeric" [% IF column.return_type == "numeric" %]selected[% END %]>Decimal</option>
-                    </select>
-                </div>
-                <div class="form-group">
-                    <label for="code_calc">Calculation: [% whats_this('helpcalc') %]</label>
-                    <textarea class="form-control monospace" id="code_calc" name="code_calc" rows="10">[% column.code | html_entity %]</textarea>
-                </div>
-                <div class="form-group">
-                    <label for="no_alerts_calc">Alerts:</label>
-                    <div class="checkbox">
-                        <label>
-                            <input id="no_alerts_calc" type="checkbox" name="no_alerts_calc" checked>Do not send alerts when making this update
-                                (alerts will still be sent when records are subsequently edited individually)
-                        </label>
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label for="no_cache_update">Status updates:</label>
-                    <div class="radio">
-                        <label>
-                            <input type="radio" name="no_cache_update" value="0" checked>Update all existing values immediately
-                        </label>
-                    </div>
-                    <div class="radio">
-                        <label>
-                            <input type="radio" name="no_cache_update" value="1">Do not immediately update all existing values
-                                (values will be updated overnight instead)
-                        </label>
-                    </div>
-                </div>
-            </div>
-            <div id="divrag"
-                [% IF column.type != "rag" %]
-                    style="display:none"
-                [% END %]
-                >
-                <p>
-                    Use a RAG field to automatically generate red, amber or green indicators based on
-                    the values of other fields. You set the conditions for the RAG status using the
-                    Lua programming language.
-                </p>
-                <div class="form-group">
-                    <label for="code_rag">Conditions for this RAG status field: [% whats_this('helpcalc') %]</label>
-                    <textarea class="form-control monospace" id="code_rag" name="code_rag" rows="10">[% column.code | html_entity %]</textarea>
-                </div>
-                <div class="form-group">
-                    <label for="no_alerts_calc">Alerts:</label>
-                    <div class="checkbox">
-                        <label>
-                            <input id="no_alerts_calc" type="checkbox" name="no_alerts_calc" checked>Do not send alerts when making this update
-                                (alerts will still be sent when records are subsequently edited individually)
-                        </label>
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label for="no_cache_update">Status updates:</label>
-                    <div class="radio">
-                        <label>
-                            <input type="radio" name="no_cache_update" value="0" checked>Update all existing values immediately
-                        </label>
-                    </div>
-                    <div class="radio">
-                        <label>
-                            <input type="radio" name="no_cache_update" value="1">Do not immediately update all existing values
-                                (values will be updated overnight instead)
-                        </label>
+                    <div class="form-group">
+                        <label for="no_cache_update">Status updates:</label>
+                        <div class="radio">
+                            <label>
+                                <input type="radio" name="no_cache_update" value="0" checked>Update all existing values immediately
+                            </label>
+                        </div>
+                        <div class="radio">
+                            <label>
+                                <input type="radio" name="no_cache_update" value="1">Do not immediately update all existing values
+                                    (values will be updated overnight instead)
+                            </label>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
-    <div class="row controls">
-        <div class="col-md-12">
-            <button type="submit" id="submit_save" name="submit" value="submit" class="btn btn-primary">[% IF column.id %]Save[% ELSE %]Save[% END %]</button>
-        [% IF column.id %]
-            <a href="/layout/" class="btn btn-default">Cancel</a>
-            <a href="" class="btn btn-default" data-toggle="modal" data-target="#myModal">Delete</a>
-        [% END %]
+        
+        [% PROCESS layout_permissions %]
+
+        <div class="row controls">
+            <div class="col-md-12">
+                <button type="submit" id="submit_save" name="submit" value="submit" class="btn btn-primary">[% IF column.id %]Save[% ELSE %]Save[% END %]</button>
+            [% IF column.id %]
+                <a href="/layout/" class="btn btn-default">Cancel</a>
+                <a href="" class="btn btn-default" data-toggle="modal" data-target="#myModal">Delete</a>
+            [% END %]
+            </div>
         </div>
-    </div>
-</form>
-<p></p>
-       <!-- Modal -->
-        <div class="modal fade" id="helprag" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                        <h4 class="modal-title" id="myModalLabel">RAG values</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>[% global.helptext.layout_rag %]</p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                    </div>
-                </div><!-- /.modal-content -->
-            </div><!-- /.modal-dialog -->
-        </div><!-- /.modal -->
-       <!-- Modal -->
-        <div class="modal fade" id="helpcalc" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                        <h4 class="modal-title" id="myModalLabel">Calculated and RAG values</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>[% global.helptext.layout_calc %]</p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                    </div>
-                </div><!-- /.modal-content -->
-            </div><!-- /.modal-dialog -->
-        </div><!-- /.modal -->
-       <!-- Modal -->
-        <div class="modal fade" id="modalhelp_match" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                        <h4 class="modal-title" id="myModalLabel">Matching field values</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>[% global.helptext.layout_match %]</p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                    </div>
-                </div><!-- /.modal-content -->
-            </div><!-- /.modal-dialog -->
-        </div><!-- /.modal -->
-       <!-- Modal -->
-        <div class="modal fade" id="modalhelp_name_short" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                        <h4 class="modal-title" id="myModalLabel">Field short names</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>[% global.helptext.name_short %]</p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                    </div>
-                </div><!-- /.modal-content -->
-            </div><!-- /.modal-dialog -->
-        </div><!-- /.modal -->
-       <!-- Modal -->
-        <div class="modal fade" id="modalhelp_groups" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                        <h4 class="modal-title" id="myModalLabel">Permissions</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>[% global.helptext.layout_groups %]</p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                    </div>
-                </div><!-- /.modal-content -->
-            </div><!-- /.modal-dialog -->
-        </div><!-- /.modal -->
-       <!-- Modal -->
-        <div class="modal fade" id="modalhelp_force_regex" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                        <h4 class="modal-title" id="myModalLabel">Force input format</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>[% global.helptext.force_regex %]</p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                    </div>
-                </div><!-- /.modal-content -->
-            </div><!-- /.modal-dialog -->
-        </div><!-- /.modal -->
-       <!-- Modal -->
-        <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <form role="form" method="post" enctype="multipart/form-data">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                        <h4 class="modal-title" id="myModalLabel">Are you sure?</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>Are you sure you want to delete this item? Deleting an item will also delete all its associated data.</p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                        <button type="submit" name="delete" value="delete" class="btn btn-primary">Confirm deletion</button>
-                    </div>
-                    </form>
-                </div><!-- /.modal-content -->
-            </div><!-- /.modal-dialog -->
-        </div><!-- /.modal -->
-        [% WRAPPER modal_dialog.tt
-            modal_id="modal_access_control" modal_action_text="Save" modal_heading="Access Control"
-            modal_with_cancel_button = 1 modal_with_form = 1 modal_form_method = "post"
-        %]
-            [% IF groups.all.size %]
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th>Group</th>
-                            <th>Read</th>
-                            <th>Write values to new records</th>
-                            <th>Edit existing values</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        [% IF column.permissions.keys.size %]
-                            [% all_perms = column.permissions.keys %]
-                        [% ELSE %]
-                            [% all_perms = [ 0 ] %]
-                        [% END %]
-                        [% FOREACH perm IN all_perms %]
-                            <tr class="permission_row">
-                                <td>
-                                    <select class="form-control" name="group_id">
-                                        <option></option>
-                                        [% FOR group IN groups.all %]
-                                            <option value="[% group.id %]" [% IF group.id == perm %]selected[% END %]>[% group.name %]</option>
-                                        [% END %]
-                                    </select>
-                                </td>
-                                <td>
-                                    <input type="hidden" name="read" value="holder">
-                                    <input type="checkbox" name="read" [% IF column.group_has(perm, 'read') %]checked[% END %]>
-                                </td>
-                                <td>
-                                    <input type="hidden" name="write_new" value="holder">
-                                    <input type="checkbox" name="write_new" [% IF column.group_has(perm, 'write_new') %]checked[% END %]>
-                                </td>
-                                <td>
-                                    <input type="hidden" name="write_existing" value="holder">
-                                    <input type="checkbox" name="write_existing" [% IF column.group_has(perm, 'write_existing') %]checked[% END %]>
-                                </td>
-                                <td>
-                                    <a class="btn btn-primary btn-sm cloneme"><i class="fa fa-lg fa-plus" style="cursor: pointer"></i></a>
-                                    <a class="btn btn-primary btn-sm removeme"><i class="fa fa-lg fa-minus" style="cursor: pointer"></i></a>
-                                </td>
-                            </tr>
-                        [% END %]
-                    </tbody>
-                </table>
-            [% ELSE %]
-                <p>No groups have been created yet. <a href="/group">Click here</a> to create a group.</p>
-            [% END %]
-        [% END %]
-        [% WRAPPER modal_dialog.tt
-            modal_id="modal_approval_control" modal_action_text="Save" modal_heading="Approval Control"
-            modal_with_cancel_button = 1 modal_with_form = 1 modal_form_method = "post"
-        %]
-            [% IF groups.all.size %]
-                <table class="table">
-                    <thead>
-                        <tr>
-                            <th>Group</th>
-                            <th>No approval required for new records</th>
-                            <th>No approval required for editing values</th>
-                            <th>Approve new values</th>
-                            <th>Approve edits</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        [% IF column.permissions.keys.size %]
-                            [% all_perms = column.permissions.keys %]
-                        [% ELSE %]
-                            [% all_perms = [ 0 ] %]
-                        [% END %]
-                        [% FOREACH perm IN all_perms %]
-                            <tr class="permission_row">
-                                <td>
-                                    <select class="form-control" name="group_id">
-                                        <option></option>
-                                        [% FOR group IN groups.all %]
-                                            <option value="[% group.id %]" [% IF group.id == perm %]selected[% END %]>[% group.name %]</option>
-                                        [% END %]
-                                    </select>
-                                </td>
-                                <td>
-                                    <input type="hidden" name="write_new_no_approval" value="holder">
-                                    <input type="checkbox" name="write_new_no_approval" [% IF column.group_has(perm, 'write_new_no_approval') %]checked[% END %]>
-                                </td>
-                                <td>
-                                    <input type="hidden" name="write_existing_no_approval" value="holder">
-                                    <input type="checkbox" name="write_existing_no_approval" [% IF column.group_has(perm, 'write_existing_no_approval') %]checked[% END %]>
-                                </td>
-                                <td>
-                                    <input type="hidden" name="approve_new" value="holder">
-                                    <input type="checkbox" name="approve_new" [% IF column.group_has(perm, 'approve_new') %]checked[% END %]>
-                                </td>
-                                <td>
-                                    <input type="hidden" name="approve_existing" value="holder">
-                                    <input type="checkbox" name="approve_existing" [% IF column.group_has(perm, 'approve_existing') %]checked[% END %]>
-                                </td>
-                                <td>
-                                    <a class="btn btn-primary btn-sm cloneme"><i class="fa fa-lg fa-plus" style="cursor: pointer"></i></a>
-                                    <a class="btn btn-primary btn-sm removeme"><i class="fa fa-lg fa-minus" style="cursor: pointer"></i></a>
-                                </td>
-                            </tr>
-                        [% END %]
-                    </tbody>
-                </table>
-            [% ELSE %]
-                <p>No groups have been created yet. <a href="/group">Click here</a> to create a group.</p>
-            [% END %]
-        [% END %]
-[% ELSE %]
-<h2>Manage fields in [% instance_name | html %]</h2>
-
-<p class="lead">
-    Each field is a column in your table. You can control which groups of users can see, edit and delete each field.
-</p>
-<p>
-    <strong>Ordering your fields:</strong> Drag and drop the fields below to reorder them at any time.
-    Click the <strong>Save order</strong> button once you are finished.
-</p>
-
-The layout defines the fields that form the overall dataset. Use this page to add, delete
-and edit fields. Each field's permissions can be individually defined; full details of the
-available permissions are detailed in the <a href="[% url.page %]/user/">Users menu</a>.</p>
-<p>Note: drag and drop rows (and click Save order) to reorder the columns.</p>
-<p>
-    <a href="/layout/0" class="btn btn-default" role="button">Add a field</a>
-</p>
-<form role="form" method="post">
-<table class="table table-striped">
-    <thead>
-        <tr>
-            <th></th>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody id="sortable">
-        [% FOREACH col IN all_columns %]
-        <tr>
-            <input type="hidden" name="position" value="[% col.id %]">
-            <td><a href="/layout/[% col.id %]">Edit</a></td>
-            <td>[% col.name | html_entity %]
-            <td>
-                [% IF col.type == "string" %]Text[% END %]
-                [% IF col.type == "intgr" %]Integer[% END %]
-                [% IF col.type == "date" %]Date[% END %]
-                [% IF col.type == "daterange" %]Date range[% END %]
-                [% IF col.type == "enum" %]Select[% END %]
-                [% IF col.type == "tree" %]Tree[% END %]
-                [% IF col.type == "file" %]File[% END %]
-                [% IF col.type == "person" %]Person[% END %]
-                [% IF col.type == "rag" %]RedAmberGreen (RAG) status[% END %]
-                [% IF col.type == "calc" %]Calculated value[% END %]
-                [% IF col.type == "curval" %]Record from other data sheet[% END %]
-            </td>
-            <td>
-                [% col.description | html_entity %]
-            </td>
-        </tr>
-        [% END %]
-    </tbody>
-</table>
-<button type="submit" id="submit_saceorder" name="saveposition" value="submit" class="btn btn-primary">Save order</button>
-</form>
-
-</div> <!-- /manage-fields -->
+    </form>
+           <!-- Modal -->
 [% END %]
 
-<script type="text/javascript">
-    var jscode='[% FILTER remove('\n+') %]
-        [% FILTER replace('\'', '\\\'') %]
+[% BLOCK list_fields %]
+    <h2>Manage fields in [% instance_name | html %]</h2>
 
-        $(document).on("click", ".cloneme", function() {
-            var parent = $(this).parents('.permission_row');
-            var cloned = parent.clone(true);
-            cloned.removeAttr('id').insertAfter(parent);
-            cloned.find(".datepicker").datepicker({format: "[% config.dateformat_datepicker %]", autoclose: true});
-        });
-        $('.removeme').click(function() {
-            var parent = $(this).parents('.permission_row');
-            if (parent.siblings(".permission_row").length > 0) {
-                parent.remove();
-            }
-        });
+    <p class="lead">
+        Each field is a column in your table. You can control which groups of users can see, edit and delete each field.
+    </p>
+    <p>
+        <strong>Ordering your fields:</strong> Drag and drop the fields below to reorder them at any time.
+        Click the <strong>Save order</strong> button once you are finished.
+    </p>
 
-        function demo_delete() {
-            var ref = $('#jstree_demo_div').jstree(true),
-                sel = ref.get_selected();
-            if(!sel.length) { return false; }
-            ref.delete_node(sel);
-        };
-        function demo_create() {
-            var ref = $('#jstree_demo_div').jstree(true),
-                sel = ref.get_selected();
-            if(sel.length) {
-                sel = sel[0];
-            } else {
-                sel = '#';
-            }
-            sel = ref.create_node(sel, {"type":"file"});
-            if(sel) {
-                ref.edit(sel);
-            }
-        };
-        function demo_rename() {
-            var ref = $('#jstree_demo_div').jstree(true),
-                sel = ref.get_selected();
-            if(!sel.length) { return false; }
-            sel = sel[0];
-            ref.edit(sel);
-        };
-            $('#selectall').click(function() {
-                if ($('.check_perm:checked').length == 7) {
-                    $('.check_perm').prop('checked', false);
+    The layout defines the fields that form the overall dataset. Use this page to add, delete
+    and edit fields. Each field's permissions can be individually defined; full details of the
+    available permissions are detailed in the <a href="[% url.page %]/user/">Users menu</a>.</p>
+    <p>Note: drag and drop rows (and click Save order) to reorder the columns.</p>
+    <p>
+        <a href="/layout/0" class="btn btn-default">Add a field</a>
+    </p>
+    <form role="form" method="post">
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th></th>
+                <th>Name</th>
+                <th>Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody id="sortable">
+            [% FOREACH col IN all_columns %]
+            <tr>
+                <input type="hidden" name="position" value="[% col.id %]">
+                <td><a href="/layout/[% col.id %]">Edit</a></td>
+                <td>[% col.name | html_entity %]
+                <td>
+                    [% IF col.type == "string" %]Text[% END %]
+                    [% IF col.type == "intgr" %]Integer[% END %]
+                    [% IF col.type == "date" %]Date[% END %]
+                    [% IF col.type == "daterange" %]Date range[% END %]
+                    [% IF col.type == "enum" %]Select[% END %]
+                    [% IF col.type == "tree" %]Tree[% END %]
+                    [% IF col.type == "file" %]File[% END %]
+                    [% IF col.type == "person" %]Person[% END %]
+                    [% IF col.type == "rag" %]RedAmberGreen (RAG) status[% END %]
+                    [% IF col.type == "calc" %]Calculated value[% END %]
+                    [% IF col.type == "curval" %]Record from other data sheet[% END %]
+                </td>
+                <td>
+                    [% col.description | html_entity %]
+                </td>
+            </tr>
+            [% END %]
+        </tbody>
+    </table>
+    <button type="submit" id="submit_saceorder" name="saveposition" value="submit" class="btn btn-primary">Save order</button>
+    </form>
+[% END %]
+
+[% BLOCK javascript %]
+    <script type="text/javascript">
+        var jscode='[% FILTER remove('\n+') %]
+            [% FILTER replace('\'', '\\\'') %]
+
+            $(document).on("click", ".cloneme", function() {
+                var parent = $(this).parents('.permission_row');
+                var cloned = parent.clone(true);
+                cloned.removeAttr('id').insertAfter(parent);
+                cloned.find(".datepicker").datepicker({format: "[% config.dateformat_datepicker %]", autoclose: true});
+            });
+            $('.removeme').click(function() {
+                var parent = $(this).parents('.permission_row');
+                if (parent.siblings(".permission_row").length > 0) {
+                    parent.remove();
+                }
+            });
+
+            function demo_delete() {
+                var ref = $('#jstree_demo_div').jstree(true),
+                    sel = ref.get_selected();
+                if(!sel.length) { return false; }
+                ref.delete_node(sel);
+            };
+            function demo_create() {
+                var ref = $('#jstree_demo_div').jstree(true),
+                    sel = ref.get_selected();
+                if(sel.length) {
+                    sel = sel[0];
                 } else {
-                    $('.check_perm').prop('checked', true);
+                    sel = '#';
                 }
-            });
-        $(document).ready(function () {
-            $('#sortable').sortable({
-                cancel: "a"
-            });
-            $('#display_condition').click(function () {
-                $("#display_condition_div").toggle(400);
-            });
-            $('#jstree_demo_div').jstree({
-                "core" : {
-                    "check_callback" : true,
-                    "force_text" : true,
-                    "themes" : { "stripes" : true },
-                    'data' : {
-                        'url' : function (node) {
-                            return '/tree' + new Date().getTime() + '/[% column.id %]?' ;
-                        },
-                        'data' : function (node) {
-                            return { 'id' : node.id };
-                        }
+                sel = ref.create_node(sel, {"type":"file"});
+                if(sel) {
+                    ref.edit(sel);
+                }
+            };
+            function demo_rename() {
+                var ref = $('#jstree_demo_div').jstree(true),
+                    sel = ref.get_selected();
+                if(!sel.length) { return false; }
+                sel = sel[0];
+                ref.edit(sel);
+            };
+                $('#selectall').click(function() {
+                    if ($('.check_perm:checked').length == 7) {
+                        $('.check_perm').prop('checked', false);
+                    } else {
+                        $('.check_perm').prop('checked', true);
                     }
-                },
-            });
-            $('div#legs').on('click','.closeme', function(){
-                var count = $(".request-row").length;
-                if (count < 2) return;
-                $(this).parents('.request-row').remove();
-            });
-            $('div#legs').on('click','.add', function(){
-                $(this).parents('.request-add').before( '
-                    <div class="request-row">
-                    <div class="col-md-11">
-                    <p>
-                    <input type="text" class="form-control" name="enumval">
-                    </p>
-                    </div>
-                    <button type="button" class="close closeme pull-left">&times;</button>
-                    </div>
-                ' );
-            });
-            $('#refers_to_instance').change(function(){
-                var divid = '#instance_fields_' + $(this).val();
-                $('.instance_fields').hide();
-                $(divid).show();
-            });
-            [% FOREACH instance IN instance_layouts %]
-                [% PROCESS builder.tt builder_id = instance.layout.instance_id layout = instance.layout filter_normal = column.filter filter_base64 = column.filter.base64 %]
-            [% END %]
-            [% IF column.filter.as_json AND NOT column.filter.as_json.match('^[{}\s]*$') %]
-                var data = decodeBase64('[% column.filter.base64 %]');
-                $('#builder[% column.refers_to_instance %]').queryBuilder('setRules',
-                    JSON.parse(data)
-                );
-            [% END %]
+                });
+            $(document).ready(function () {
+                $('#sortable').sortable({
+                    cancel: "a"
+                });
+                $('#display_condition').click(function () {
+                    $("#display_condition_div").toggle(400);
+                });
+                $('#jstree_demo_div').jstree({
+                    "core" : {
+                        "check_callback" : true,
+                        "force_text" : true,
+                        "themes" : { "stripes" : true },
+                        'data' : {
+                            'url' : function (node) {
+                                return '/tree' + new Date().getTime() + '/[% column.id %]?' ;
+                            },
+                            'data' : function (node) {
+                                return { 'id' : node.id };
+                            }
+                        }
+                    },
+                });
+                $('div#legs').on('click','.closeme', function(){
+                    var count = $(".request-row").length;
+                    if (count < 2) return;
+                    $(this).parents('.request-row').remove();
+                });
+                $('div#legs').on('click','.add', function(){
+                    $(this).parents('.request-add').before( '
+                        <div class="request-row">
+                        <div class="col-md-11">
+                        <p>
+                        <input type="text" class="form-control" name="enumval">
+                        </p>
+                        </div>
+                        <button type="button" class="close closeme pull-left">&times;</button>
+                        </div>
+                    ' );
+                });
+                $('#refers_to_instance').change(function(){
+                    var divid = '#instance_fields_' + $(this).val();
+                    $('.instance_fields').hide();
+                    $(divid).show();
+                });
+                [% FOREACH instance IN instance_layouts %]
+                    [% PROCESS builder.tt builder_id = instance.layout.instance_id layout = instance.layout filter_normal = column.filter filter_base64 = column.filter.base64 %]
+                [% END %]
+                [% IF column.filter.as_json AND NOT column.filter.as_json.match('^[{}\s]*$') %]
+                    var data = decodeBase64('[% column.filter.base64 %]');
+                    $('#builder[% column.refers_to_instance %]').queryBuilder('setRules',
+                        JSON.parse(data)
+                    );
+                [% END %]
 
-            $('#submit_save').click(function() {
-                var current_builder = "#builder" + $('#refers_to_instance').val();
-                if( $('#jstree_demo_div').length && $('#jstree_demo_div').is(":visible") ) {
-                    var v =$("#jstree_demo_div").jstree(true).get_json('#', { 'flat': false });
-                    var mytext = JSON.stringify(v);
-                    $.ajax({
-                        async: false,
-                        type: "POST",
-                        url: "/tree/[% column.id %]",
-                        data: {'data': mytext }
-                    }).done(function( data ) {
-                        alert( "Tree has been updated" );
-                    });
+                $('#submit_save').click(function() {
+                    var current_builder = "#builder" + $('#refers_to_instance').val();
+                    if( $('#jstree_demo_div').length && $('#jstree_demo_div').is(":visible") ) {
+                        var v =$("#jstree_demo_div").jstree(true).get_json('#', { 'flat': false });
+                        var mytext = JSON.stringify(v);
+                        $.ajax({
+                            async: false,
+                            type: "POST",
+                            url: "/tree/[% column.id %]",
+                            data: {'data': mytext }
+                        }).done(function( data ) {
+                            alert( "Tree has been updated" );
+                        });
+                        return true;
+                    } else if ($(current_builder).is(":visible")) {
+                        UpdateFilter($(current_builder));
+                    }
                     return true;
-                } else if ($(current_builder).is(":visible")) {
-                    UpdateFilter($(current_builder));
-                }
-                return true;
-            });
-            $('#type').change(function(){
-                $('#divenum').hide();
-                $('#divtree').show();
-                var val = $(this).val();
-                if (val == "tree") {
+                });
+                $('#type').change(function(){
                     $('#divenum').hide();
                     $('#divtree').show();
-                    $('#divcalc').hide();
-                    $('#divrag').hide();
-                    $('#divfile').hide();
-                    $('#divcurval').hide();
-                    $('#divstring').hide();
-                    $('#divdate').hide();
-                    $('.noragcalc').show();
-                } else if (val == "enum") {
-                    $('#divenum').show();
-                    $('#divtree').hide();
-                    $('#divcalc').hide();
-                    $('#divrag').hide();
-                    $('#divfile').hide();
-                    $('#divcurval').hide();
-                    $('#divstring').hide();
-                    $('#divdate').hide();
-                    $('.noragcalc').show();
-                } else if (val == "rag") {
-                    $('#divrag').show();
-                    $('#divtree').hide();
-                    $('#divenum').hide();
-                    $('#divcalc').hide();
-                    $('#divfile').hide();
-                    $('#divcurval').hide();
-                    $('#divstring').hide();
-                    $('#divdate').hide();
-                    $('.noragcalc').hide();
-                } else if (val == "calc") {
-                    $('#divrag').hide();
-                    $('#divtree').hide();
-                    $('#divenum').hide();
-                    $('#divcalc').show();
-                    $('#divfile').hide();
-                    $('#divcurval').hide();
-                    $('#divstring').hide();
-                    $('#divdate').hide();
-                    $('.noragcalc').hide();
-                } else if (val == "file") {
-                    $('#divcalc').hide();
-                    $('#divrag').hide();
-                    $('#divtree').hide();
-                    $('#divenum').hide();
-                    $('#divfile').show();
-                    $('#divcurval').hide();
-                    $('#divstring').hide();
-                    $('#divdate').hide();
-                    $('.noragcalc').show();
-                } else if (val == "curval") {
-                    $('#divcalc').hide();
-                    $('#divrag').hide();
-                    $('#divtree').hide();
-                    $('#divenum').hide();
-                    $('#divfile').hide();
-                    $('#divcurval').show();
-                    $('#divstring').hide();
-                    $('#divdate').hide();
-                    $('.noragcalc').show();
-                } else if (val == "string") {
-                    $('#divcalc').hide();
-                    $('#divrag').hide();
-                    $('#divtree').hide();
-                    $('#divenum').hide();
-                    $('#divfile').hide();
-                    $('#divcurval').hide();
-                    $('#divstring').show();
-                    $('#divdate').hide();
-                    $('.noragcalc').show();
-                } else if (val == "date" || val == "daterange") {
-                    $('#divcalc').hide();
-                    $('#divrag').hide();
-                    $('#divtree').hide();
-                    $('#divenum').hide();
-                    $('#divfile').hide();
-                    $('#divcurval').hide();
-                    $('#divstring').hide();
-                    $('#divdate').show();
-                    $('.noragcalc').show();
-                } else {
-                    $('#divenum').hide();
-                    $('#divtree').hide();
-                    $('#divcalc').hide();
-                    $('#divrag').hide();
-                    $('#divfile').hide();
-                    $('#divcurval').hide();
-                    $('#divstring').hide();
-                    $('#divdate').hide();
-                    $('.noragcalc').show();
-                }
-            });
-        }); 
+                    var val = $(this).val();
+                    if (val == "tree") {
+                        $('#divenum').hide();
+                        $('#divtree').show();
+                        $('#divcalc').hide();
+                        $('#divrag').hide();
+                        $('#divfile').hide();
+                        $('#divcurval').hide();
+                        $('#divstring').hide();
+                        $('#divdate').hide();
+                        $('.noragcalc').show();
+                    } else if (val == "enum") {
+                        $('#divenum').show();
+                        $('#divtree').hide();
+                        $('#divcalc').hide();
+                        $('#divrag').hide();
+                        $('#divfile').hide();
+                        $('#divcurval').hide();
+                        $('#divstring').hide();
+                        $('#divdate').hide();
+                        $('.noragcalc').show();
+                    } else if (val == "rag") {
+                        $('#divrag').show();
+                        $('#divtree').hide();
+                        $('#divenum').hide();
+                        $('#divcalc').hide();
+                        $('#divfile').hide();
+                        $('#divcurval').hide();
+                        $('#divstring').hide();
+                        $('#divdate').hide();
+                        $('.noragcalc').hide();
+                    } else if (val == "calc") {
+                        $('#divrag').hide();
+                        $('#divtree').hide();
+                        $('#divenum').hide();
+                        $('#divcalc').show();
+                        $('#divfile').hide();
+                        $('#divcurval').hide();
+                        $('#divstring').hide();
+                        $('#divdate').hide();
+                        $('.noragcalc').hide();
+                    } else if (val == "file") {
+                        $('#divcalc').hide();
+                        $('#divrag').hide();
+                        $('#divtree').hide();
+                        $('#divenum').hide();
+                        $('#divfile').show();
+                        $('#divcurval').hide();
+                        $('#divstring').hide();
+                        $('#divdate').hide();
+                        $('.noragcalc').show();
+                    } else if (val == "curval") {
+                        $('#divcalc').hide();
+                        $('#divrag').hide();
+                        $('#divtree').hide();
+                        $('#divenum').hide();
+                        $('#divfile').hide();
+                        $('#divcurval').show();
+                        $('#divstring').hide();
+                        $('#divdate').hide();
+                        $('.noragcalc').show();
+                    } else if (val == "string") {
+                        $('#divcalc').hide();
+                        $('#divrag').hide();
+                        $('#divtree').hide();
+                        $('#divenum').hide();
+                        $('#divfile').hide();
+                        $('#divcurval').hide();
+                        $('#divstring').show();
+                        $('#divdate').hide();
+                        $('.noragcalc').show();
+                    } else if (val == "date" || val == "daterange") {
+                        $('#divcalc').hide();
+                        $('#divrag').hide();
+                        $('#divtree').hide();
+                        $('#divenum').hide();
+                        $('#divfile').hide();
+                        $('#divcurval').hide();
+                        $('#divstring').hide();
+                        $('#divdate').show();
+                        $('.noragcalc').show();
+                    } else {
+                        $('#divenum').hide();
+                        $('#divtree').hide();
+                        $('#divcalc').hide();
+                        $('#divrag').hide();
+                        $('#divfile').hide();
+                        $('#divcurval').hide();
+                        $('#divstring').hide();
+                        $('#divdate').hide();
+                        $('.noragcalc').show();
+                    }
+                });
+            }); 
+    [% END %]
+    [% END %]';
+    </script>
 [% END %]
-[% END %]';
-</script>
 
+<div class="manage-fields">
+    [% 
+        IF column.defined;
+            PROCESS edit_field;
+        ELSE;
+            PROCESS manage_fields;
+        END;
 
+        PROCESS layout_modals;
+        PROCESS javascript;
+    %]
+</div>

--- a/views/layout.tt
+++ b/views/layout.tt
@@ -130,402 +130,409 @@
     </div><!-- /.modal -->
 [% END %]
 
-[% BLOCK edit_field %]
-    <h2>[% IF column.id %]Edit field[% ELSE %]Add a field to [% instance_name | html %][% END %]</h2>
+[% BLOCK edit_field_left_column %]
+    <div class="col-md-6 col-sm-12 col-xs-12">
+        <section id="options">
+            <h3>Options</h3>
 
-    <form role="form" method="post">
-        <div class="row">
-            <div class="col-md-6">
-                [% IF column.id %]
-                    <input type="hidden" name="id" value="[% column.id %]">
-                [% END %]
-                [% IF column.type == "rag" OR column.type == "calc" %][% noragcalc = 'style="display:none"' %][% END %]
-                <div class="form-group">
-                    <label for="name">Field name:</label>
-                    <input type="text" class="form-control" id="name" name="name" value="[% column.name | html_entity %]">
-                </div>
-                [% UNLESS column.id %]
-                    <div class="form-group">
-                        <label for="type">Type:</label>
-                        <select class="form-control" id="type" name="type">
-                            <option value="string" [% IF column.type == "string" %]selected[% END %]>Text</option>
-                            <option value="intgr" [% IF column.type == "intgr" %]selected[% END %]>Integer</option>
-                            <option value="date" [% IF column.type == "date" %]selected[% END %]>Date</option>
-                            <option value="daterange" [% IF column.type == "daterange" %]selected[% END %]>Date range</option>
-                            <option value="enum" [% IF column.type == "enum" %]selected[% END %]>Dropdown list</option>
-                            <option value="tree" [% IF column.type == "tree" %]selected[% END %]>Tree</option>
-                            <option value="file" [% IF column.type == "file" %]selected[% END %]>Document</option>
-                            <option value="person" [% IF column.type == "person" %]selected[% END %]>Person</option>
-                            <option value="rag" [% IF column.type == "rag" %]selected[% END %]>RedAmberGreen status (RAG)</option>
-                            <option value="calc" [% IF column.type == "calc" %]selected[% END %]>Calculated value</option>
-                            <option value="curval" [% IF column.type == "curval" %]selected[% END %]>Field(s) for records from another table</option>
-                        </select>
-                    </div>
-                [% END %]
-                <div class="form-group">
-                    <label for="description">Description:</label>
-                    <input type="text" class="form-control" id="description" name="description" value="[% column.description | html_entity %]">
-                </div>
-                <div class="form-group">
-                    <label for="name_short"><span style="font-weight:normal">Short name: [% whats_this('modalhelp_name_short') %]</span></label>
-                    <input type="text" class="form-control" id="name_short" name="name_short" value="[% column.name_short | html_entity %]">
-                </div>
-                <div class="form-group">
-                    <label for="link_parent_id">Link to a field in another table:</label>
-                    [% IF instance_layouts.size %]
-                        <select class="form-control" id="link_parent_id" name="link_parent_id">
-                            <option value="">&lt;Not linked&gt;</option>
-                            [% FOREACH l IN instance_layouts %]
-                                [% FOREACH c IN l.layout.all %]
-                                    <option value="[% c.id %]" [% IF column.link_parent.id == c.id %]selected[% END %]>[% l.instance.name %] - [% c.name %]</option>
-                                [% END %]
-                            [% END %]
-                        </select>
-                    [% ELSE %]
-                        <select class="form-control" id="link_parent_id" name="link_parent_id" disabled readonly>
-                            <option value="">&lt;No other datasheets exist&gt;</option>
-                        </select>
-                    [% END %]
-                </div>
-                <div class="form-group">
-                    <label for="helptext">Help text for the user:</label>
-                    <textarea class="form-control" rows="5" id="helptext" name="helptext">[% column.helptext | html_entity %]</textarea>
-                </div>
-                <div class="checkbox noragcalc" [% noragcalc %]>
-                    <label>
-                        <input type="checkbox" name="optional" [% IF column.optional %]checked[% END %]>This field is optional
-                    </label>
-                </div>
-                <div class="checkbox noragcalc" [% noragcalc %]>
-                    <label>
-                        <input type="checkbox" name="remember" [% IF column.remember %]checked[% END %]>Remember last value for new entry
-                    </label>
-                </div>
-                <div class="checkbox noragcalc" [% noragcalc %]>
-                    <label>
-                        <input type="checkbox" name="isunique" [% IF column.isunique %]checked[% END %]>The values for this field must be unique
-                    </label>
-                </div>
-                [% IF column.can_multivalue %]
-                    <div class="checkbox">
-                        <label>
-                            <input type="checkbox" name="multivalue" [% IF column.multivalue %]checked[% END %]>Allow multiple values
-                        </label>
-                    </div>
-                [% END %]
-                <div class="checkbox noragcalc" [% noragcalc %]>
-                    <label>
-                        <input type="checkbox" id="display_condition" name="display_condition" [% IF column.display_field %]checked[% END %]>Only display this field under the following conditions:
-                    </label>
-                </div>
-                <div class="form-group" id="display_condition_div" [% UNLESS column.display_field %]style="display:none"[% END %]>
-                    <div class="row">
-                        <div class="col-md-5">
-                            <select class="form-control" id="display_field" name="display_field">
-                                [% FOREACH field in all_columns %]
-                                    <option value="[% field.id %]" [% IF column.display_field == field.id %]selected[% END %]>[% field.name | html_entity %]</option>
-                                [% END %]
-                            </select>
-                        </div>
-                        <div class="col-md-2">
-                            <p>matches [% whats_this('modalhelp_match') %]</p>
-                        </div>
-                        <div class="col-md-5">
-                            <div class="form-group">
-                                <input type="text" class="form-control" id="display_regex" name="display_regex" value="[% column.display_regex | html_entity %]">
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <hr>
+            <div class="checkbox noragcalc" [% noragcalc %]>
+                <label>
+                    <input type="checkbox" name="optional" [% IF column.optional %]checked[% END %]>This field is optional
+                </label>
             </div>
-            <div class="col-md-6">
-                <div id="divtree"
-                    [% IF column.type != "tree" %]
-                        style="display:none"
-                    [% END %]
-                    >
-                    [% IF column.id %]
-                        <h4>Tree field options</h4>
-                        <p>Each value in the tree is referred to as a node.</p>
-                        <div class="checkbox">
-                            <label>
-                                <input type="checkbox" name="end_node_only" [% IF column.end_node_only %]checked[% END %]>
-                                Only let users select an end-node
-                            </label>
-                        </div>
-                        <h4>Tree nodes:</h4>
-                        <div class="form-group">
-                                <button class="btn btn-success btn-sm" onclick="demo_create();" type="button">Add a node</button>
-                                <button class="btn btn-warning btn-sm" onclick="demo_rename();" type="button">Rename</button>
-                                <button class="btn btn-danger btn-sm" onclick="demo_delete();" type="button">Delete</button>
-                                <button class="btn btn-info btn-sm" onclick="$('#jstree_demo_div').jstree('open_all');" type="button">Expand tree</button>
-                                <button class="btn btn-info btn-sm" onclick="$('#jstree_demo_div').jstree('close_all');" type="button">Collapse tree</button>
-                                <div id="jstree_demo_div"></div>
-                        </div>
-                    [% ELSE %]
-                        <p>Use a tree to structure the values that users can select into categories and sub-categories.</p>
-                        <p>To create your tree, please save this field first, then edit it.</p>
-                    [% END %]
+            <div class="checkbox noragcalc" [% noragcalc %]>
+                <label>
+                    <input type="checkbox" name="remember" [% IF column.remember %]checked[% END %]>Remember last value for new entry
+                </label>
+            </div>
+            <div class="checkbox noragcalc" [% noragcalc %]>
+                <label>
+                    <input type="checkbox" name="isunique" [% IF column.isunique %]checked[% END %]>The values for this field must be unique
+                </label>
+            </div>
+            [% IF column.can_multivalue %]
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox" name="multivalue" [% IF column.multivalue %]checked[% END %]>Allow multiple values
+                    </label>
                 </div>
-                <div id="divenum"
-                    [% IF column.type != "enum" %]
-                        style="display:none"
-                    [% END %]
-                    >
-                    <h4>Dropdown field options</h4>
-                    <div class="col-md-11">
-                        <div class="form-group">
-                            <label for="enumval">Order dropdown values:</label>
-                            <select class="form-control" name="ordering">
-                                <option value="" [% IF NOT column.ordering %]selected[% END %]>As entered</option>
-                                <option value="asc" [% IF column.ordering == "asc" %]selected[% END %]>Ascending</option>
-                                <option value="desc" [% IF column.ordering == "desc" %]selected[% END %]>Descending</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="col-md-11">
-                        <label for="enumval">Add dropdown values:</label>
-                    </div>
-                    <div id="legs">
-                        [% FOREACH enumval IN column.enumvals %]
-                            [% UNLESS enumval.deleted %]
-                                <div class="request-row">
-                                        <div class="col-md-11">
-                                            <p>
-                                            <input type="text" class="form-control" name="enumval[% enumval.id %]" value="[% enumval.value | html_entity %]">
-                                            </p>
-                                        </div>
-                                        <button type="button" class="close closeme pull-left">&times;</button>
-                                </div>
+            [% END %]
+        </section>
+
+        <section id="display_conditions">
+            <h3>Display conditions</h3>
+        [% IF column.display_field %]
+            <div class="form-group">
+                <div class="row">
+                    <div class="col-md-5">
+                        <select class="form-control" id="display_field" name="display_field">
+                            [% FOREACH field in all_columns %]
+                                <option value="[% field.id %]" [% IF column.display_field == field.id %]selected[% END %]>[% field.name | html_entity %]</option>
                             [% END %]
-                        [% END %]
-                        <div class="request-add">
-                                <div class="col-md-11">
-                                    <button type="button" class="btn btn-default add">
-                                        Add
-                                    </button>
-                                </div>
-                        </div>
-                    </div>
-                </div>
-                <div id="divcurval"
-                    [% IF column.type != "curval" %]
-                        style="display:none"
-                    [% END %]
-                    >
-                    <h4>Field options</h4>
-                    [% IF instance_layouts.size %]
-                        [% rti = column.refers_to_instance %]
-                        <div class="form-group">
-                            <div class="radio">
-                                <label>
-                                    <input type="radio" name="typeahead" value="0" [% IF NOT column.typeahead %]checked[% END %]>Provide values as a dropdown
-                                </label>
-                            </div>
-                            <div class="radio">
-                                <label>
-                                    <input type="radio" name="typeahead" value="1" [% IF column.typeahead %]checked[% END %]>Provide values as an auto-complete textbox
-                                </label>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label for="override_permissions">Permissions override:</label>
-                            <div class="checkbox">
-                                <label>
-                                    <input id="override_permissions" type="checkbox" name="override_permissions" [% IF column.override_permissions %]checked[% END %]>Override any user permissions when selecting records for this field
-                                </label>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label for="refers_to_instance">Use this table:</label>
-                            <select class="form-control" id="refers_to_instance" name="refers_to_instance">
-                                [% IF NOT rti %]
-                                    <option></option>
-                                [% END %]
-                                [% FOREACH instance IN instance_layouts %]
-                                    <option value="[% instance.instance.id %]" [% IF rti == instance.instance.id %]selected[% END %]>[% instance.instance.name | html_entity %]</option>
-                                [% END %]
-                            </select>
-                        </div>
-                        [% FOREACH instance IN instance_layouts %]
-                            <div id="instance_fields_[% instance.instance.id %]" class="instance_fields"
-                                [% IF (rti AND instance.instance.id != rti) OR NOT rti %]
-                                    style="display:none"
-                                [% END %]
-                                >
-                                <div class="form-group">
-                                    <label for="curval_instance">Show these fields:</label>
-                                    [% FOREACH c IN instance.layout.all %]
-                                        [% NEXT IF c.type == "curval" %]
-                                        [% checked = "" %]
-                                        [% IF instance.instance.id == rti AND column.has_curval_field(c.id) %]
-                                            [% checked = "checked" %]
-                                        [% END %]
-                                        <div class="checkbox">
-                                            <label>
-                                                <input type="checkbox" name="curval_field_ids" value="[% c.id %]" [% checked %]>[% c.name %]
-                                            </label>
-                                        </div>
-                                    [% END %]
-                                </div>
-                                <div class="form-group">
-                                        <label for="builder[% instance.layout.instance_id %]">Apply the following filters to records in the selected table::</label>
-                                        <div id="builder[% instance.layout.instance_id %]"></div>
-                                </div>
-                            </div>
-                        [% END %]
-                        <input id="filter" type="hidden" name="filter" value="[% column.filter.as_json | html_entity %]">
-                    [% ELSE %]
-                        <div class="alert alert-info">
-                            No other instances are available to select data from
-                        </div>
-                    [% END %]
-                </div>
-                <div id="divfile"
-                    [% IF column.type != "file" %]
-                        style="display:none"
-                    [% END %]
-                    >
-                    <h4>Document field options</h4>
-                    <div class="form-group">
-                        <label for="filesize">Set maximum file size (KB): (Leave blank for no limit)</label>
-                        <input type="text" class="form-control" name="filesize" id="filesize"
-                            value="[% column.filesize %]" placeholder="Leave blank for no limit">
-                    </div>
-                </div>
-                <div id="divstring"
-                        [% IF column.type != "string" %]
-                            style="display:none"
-                        [% END %]
-                    >
-                    <h4>Text field options</h4>
-                    <div class="form-group">
-                        <div class="checkbox">
-                            <label>
-                                <input id="textbox" type="checkbox" name="textbox" [% IF column.textbox %]checked[% END %]>Make this a multi-line text box
-                            </label>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label for="force_regex">Require the field value to be in a particular format: [% whats_this('modalhelp_force_regex') %]</label>
-                        <input id="force_regex" class="form-control" type="text" name="force_regex" value="[% column.force_regex | html_entity %]">
-                    </div>
-                </div>
-                <div id="divdate"
-                        [% IF column.type != "date" AND column.type != "daterange" %]
-                            style="display:none"
-                        [% END %]
-                    >
-                    <div class="form-group">
-                        <label for="show_datepicker">Show date picker:</label>
-                        <div class="checkbox">
-                            <label>
-                                <input id="show_datepicker" type="checkbox" name="show_datepicker" [% IF NOT column.show_datepicker.defined OR column.show_datepicker %]checked[% END %]>Show date picker pop-up
-                            </label>
-                        </div>
-                    </div>
-                </div>
-                <div id="divcalc"
-                    [% IF column.type != "calc" %]
-                        style="display:none"
-                    [% END %]
-                    >
-                    <p>
-                        A calculated value field automatically generates values based on the values
-                        of other fields. You define your calculation using the Lua programming language.
-                    </p>
-                    <div class="form-group">
-                        <label for="return_type">Return value conversion:</label>
-                        <select class="form-control" name="return_type">
-                            <option value="string" [% IF column.return_type == "string" %]selected[% END %]>String</option>
-                            <option value="date" [% IF column.return_type == "date" %]selected[% END %]>Date</option>
-                            <option value="integer" [% IF column.return_type == "integer" %]selected[% END %]>Integer</option>
-                            <option value="numeric" [% IF column.return_type == "numeric" %]selected[% END %]>Decimal</option>
                         </select>
                     </div>
-                    <div class="form-group">
-                        <label for="code_calc">Calculation: [% whats_this('helpcalc') %]</label>
-                        <textarea class="form-control monospace" id="code_calc" name="code_calc" rows="10">[% column.code | html_entity %]</textarea>
+                    <div class="col-md-2">
+                        <p>matches [% whats_this('modalhelp_match') %]</p>
                     </div>
-                    <div class="form-group">
-                        <label for="no_alerts_calc">Alerts:</label>
-                        <div class="checkbox">
-                            <label>
-                                <input id="no_alerts_calc" type="checkbox" name="no_alerts_calc" checked>Do not send alerts when making this update
-                                    (alerts will still be sent when records are subsequently edited individually)
-                            </label>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label for="no_cache_update">Status updates:</label>
-                        <div class="radio">
-                            <label>
-                                <input type="radio" name="no_cache_update" value="0" checked>Update all existing values immediately
-                            </label>
-                        </div>
-                        <div class="radio">
-                            <label>
-                                <input type="radio" name="no_cache_update" value="1">Do not immediately update all existing values
-                                    (values will be updated overnight instead)
-                            </label>
-                        </div>
-                    </div>
-                </div>
-                <div id="divrag"
-                    [% IF column.type != "rag" %]
-                        style="display:none"
-                    [% END %]
-                    >
-                    <p>
-                        Use a RAG field to automatically generate red, amber or green indicators based on
-                        the values of other fields. You set the conditions for the RAG status using the
-                        Lua programming language.
-                    </p>
-                    <div class="form-group">
-                        <label for="code_rag">Conditions for this RAG status field: [% whats_this('helpcalc') %]</label>
-                        <textarea class="form-control monospace" id="code_rag" name="code_rag" rows="10">[% column.code | html_entity %]</textarea>
-                    </div>
-                    <div class="form-group">
-                        <label for="no_alerts_calc">Alerts:</label>
-                        <div class="checkbox">
-                            <label>
-                                <input id="no_alerts_calc" type="checkbox" name="no_alerts_calc" checked>Do not send alerts when making this update
-                                    (alerts will still be sent when records are subsequently edited individually)
-                            </label>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label for="no_cache_update">Status updates:</label>
-                        <div class="radio">
-                            <label>
-                                <input type="radio" name="no_cache_update" value="0" checked>Update all existing values immediately
-                            </label>
-                        </div>
-                        <div class="radio">
-                            <label>
-                                <input type="radio" name="no_cache_update" value="1">Do not immediately update all existing values
-                                    (values will be updated overnight instead)
-                            </label>
+                    <div class="col-md-5">
+                        <div class="form-group">
+                            <input type="text" class="form-control" id="display_regex" name="display_regex" value="[% column.display_regex | html_entity %]">
                         </div>
                     </div>
                 </div>
             </div>
-        </div>
-        
+        [% ELSE %]
+            <div class="col-md-12">This field is always displayed.</div>
+            <div class="col-md-12">
+                <button type="button" class="btn btn-default" id="add_display_regex">Define condition</button>
+            </div>
+        [% END %]
+        </section>
+
+        <section id="properties">
+            <h3>Properties</h3>
+
+            <div class="form-group">
+                <label for="name">Field name:</label>
+                <input type="text" class="form-control" id="name" name="name" value="[% column.name | html_entity %]">
+            </div>
+            [% UNLESS column.id %]
+                <div class="form-group">
+                    <label for="type">Type:</label>
+                    <select class="form-control" id="type" name="type">
+                        <option value="string" [% IF column.type == "string" %]selected[% END %]>Text</option>
+                        <option value="intgr" [% IF column.type == "intgr" %]selected[% END %]>Integer</option>
+                        <option value="date" [% IF column.type == "date" %]selected[% END %]>Date</option>
+                        <option value="daterange" [% IF column.type == "daterange" %]selected[% END %]>Date range</option>
+                        <option value="enum" [% IF column.type == "enum" %]selected[% END %]>Dropdown list</option>
+                        <option value="tree" [% IF column.type == "tree" %]selected[% END %]>Tree</option>
+                        <option value="file" [% IF column.type == "file" %]selected[% END %]>Document</option>
+                        <option value="person" [% IF column.type == "person" %]selected[% END %]>Person</option>
+                        <option value="rag" [% IF column.type == "rag" %]selected[% END %]>RedAmberGreen status (RAG)</option>
+                        <option value="calc" [% IF column.type == "calc" %]selected[% END %]>Calculated value</option>
+                        <option value="curval" [% IF column.type == "curval" %]selected[% END %]>Field(s) for records from another table</option>
+                    </select>
+                </div>
+            [% END %]
+            <div class="form-group">
+                <label for="description">Description:</label>
+                <input type="text" class="form-control" id="description" name="description" value="[% column.description | html_entity %]">
+            </div>
+            <div class="form-group">
+                <label for="name_short"><span style="font-weight:normal">Short name: [% whats_this('modalhelp_name_short') %]</span></label>
+                <input type="text" class="form-control" id="name_short" name="name_short" value="[% column.name_short | html_entity %]">
+            </div>
+            <div class="form-group">
+                <label for="link_parent_id">Link to a field in another table:</label>
+                [% IF instance_layouts.size %]
+                    <select class="form-control" id="link_parent_id" name="link_parent_id">
+                        <option value="">&lt;Not linked&gt;</option>
+                        [% FOREACH l IN instance_layouts %]
+                            [% FOREACH c IN l.layout.all %]
+                                <option value="[% c.id %]" [% IF column.link_parent.id == c.id %]selected[% END %]>[% l.instance.name %] - [% c.name %]</option>
+                            [% END %]
+                        [% END %]
+                    </select>
+                [% ELSE %]
+                    <select class="form-control" id="link_parent_id" name="link_parent_id" disabled readonly>
+                        <option value="">&lt;No other datasheets exist&gt;</option>
+                    </select>
+                [% END %]
+            </div>
+            <div class="form-group">
+                <label for="helptext">Help text for the user:</label>
+                <textarea class="form-control" rows="5" id="helptext" name="helptext">[% column.helptext | html_entity %]</textarea>
+            </div>
+        </section>
+
         [% PROCESS layout_permissions %]
 
-        <div class="row controls">
-            <div class="col-md-12">
-                <button type="submit" id="submit_save" name="submit" value="submit" class="btn btn-primary">[% IF column.id %]Save[% ELSE %]Save[% END %]</button>
-            [% IF column.id %]
-                <a href="/layout/" class="btn btn-default">Cancel</a>
-                <a href="" class="btn btn-default" data-toggle="modal" data-target="#myModal">Delete</a>
+    </div>
+[% END %]
+
+[% BLOCK edit_field_right_column %]
+   <div class="col-md-6 col-sm-12 col-xs-12">
+        <div id="divtree"
+            [% IF column.type != "tree" %]
+                style="display:none"
             [% END %]
+            >
+            [% IF column.id %]
+                <h4>Tree field options</h4>
+                <p>Each value in the tree is referred to as a node.</p>
+                <div class="checkbox">
+                    <label>
+                        <input type="checkbox" name="end_node_only" [% IF column.end_node_only %]checked[% END %]>
+                        Only let users select an end-node
+                    </label>
+                </div>
+                <h4>Tree nodes:</h4>
+                <div class="form-group">
+                        <button class="btn btn-success btn-sm" onclick="demo_create();" type="button">Add a node</button>
+                        <button class="btn btn-warning btn-sm" onclick="demo_rename();" type="button">Rename</button>
+                        <button class="btn btn-danger btn-sm" onclick="demo_delete();" type="button">Delete</button>
+                        <button class="btn btn-info btn-sm" onclick="$('#jstree_demo_div').jstree('open_all');" type="button">Expand tree</button>
+                        <button class="btn btn-info btn-sm" onclick="$('#jstree_demo_div').jstree('close_all');" type="button">Collapse tree</button>
+                        <div id="jstree_demo_div"></div>
+                </div>
+            [% ELSE %]
+                <p>Use a tree to structure the values that users can select into categories and sub-categories.</p>
+                <p>To create your tree, please save this field first, then edit it.</p>
+            [% END %]
+        </div>
+        <div id="divenum"
+            [% IF column.type != "enum" %]
+                style="display:none"
+            [% END %]
+            >
+            <h4>Dropdown field options</h4>
+            <div class="col-md-11">
+                <div class="form-group">
+                    <label for="enumval">Order dropdown values:</label>
+                    <select class="form-control" name="ordering">
+                        <option value="" [% IF NOT column.ordering %]selected[% END %]>As entered</option>
+                        <option value="asc" [% IF column.ordering == "asc" %]selected[% END %]>Ascending</option>
+                        <option value="desc" [% IF column.ordering == "desc" %]selected[% END %]>Descending</option>
+                    </select>
+                </div>
+            </div>
+            <div class="col-md-11">
+                <label for="enumval">Add dropdown values:</label>
+            </div>
+            <div id="legs">
+                [% FOREACH enumval IN column.enumvals %]
+                    [% UNLESS enumval.deleted %]
+                        <div class="request-row">
+                                <div class="col-md-11">
+                                    <p>
+                                    <input type="text" class="form-control" name="enumval[% enumval.id %]" value="[% enumval.value | html_entity %]">
+                                    </p>
+                                </div>
+                                <button type="button" class="close closeme pull-left">&times;</button>
+                        </div>
+                    [% END %]
+                [% END %]
+                <div class="request-add">
+                        <div class="col-md-11">
+                            <button type="button" class="btn btn-default add">
+                                Add value
+                            </button>
+                        </div>
+                </div>
             </div>
         </div>
-    </form>
-           <!-- Modal -->
+        <div id="divcurval"
+            [% IF column.type != "curval" %]
+                style="display:none"
+            [% END %]
+            >
+            <h4>Field options</h4>
+            [% IF instance_layouts.size %]
+                [% rti = column.refers_to_instance %]
+                <div class="form-group">
+                    <div class="radio">
+                        <label>
+                            <input type="radio" name="typeahead" value="0" [% IF NOT column.typeahead %]checked[% END %]>Provide values as a dropdown
+                        </label>
+                    </div>
+                    <div class="radio">
+                        <label>
+                            <input type="radio" name="typeahead" value="1" [% IF column.typeahead %]checked[% END %]>Provide values as an auto-complete textbox
+                        </label>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="override_permissions">Permissions override:</label>
+                    <div class="checkbox">
+                        <label>
+                            <input id="override_permissions" type="checkbox" name="override_permissions" [% IF column.override_permissions %]checked[% END %]>Override any user permissions when selecting records for this field
+                        </label>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="refers_to_instance">Use this table:</label>
+                    <select class="form-control" id="refers_to_instance" name="refers_to_instance">
+                        [% IF NOT rti %]
+                            <option></option>
+                        [% END %]
+                        [% FOREACH instance IN instance_layouts %]
+                            <option value="[% instance.instance.id %]" [% IF rti == instance.instance.id %]selected[% END %]>[% instance.instance.name | html_entity %]</option>
+                        [% END %]
+                    </select>
+                </div>
+                [% FOREACH instance IN instance_layouts %]
+                    <div id="instance_fields_[% instance.instance.id %]" class="instance_fields"
+                        [% IF (rti AND instance.instance.id != rti) OR NOT rti %]
+                            style="display:none"
+                        [% END %]
+                        >
+                        <div class="form-group">
+                            <label for="curval_instance">Show these fields:</label>
+                            [% FOREACH c IN instance.layout.all %]
+                                [% NEXT IF c.type == "curval" %]
+                                [% checked = "" %]
+                                [% IF instance.instance.id == rti AND column.has_curval_field(c.id) %]
+                                    [% checked = "checked" %]
+                                [% END %]
+                                <div class="checkbox">
+                                    <label>
+                                        <input type="checkbox" name="curval_field_ids" value="[% c.id %]" [% checked %]>[% c.name %]
+                                    </label>
+                                </div>
+                            [% END %]
+                        </div>
+                        <div class="form-group">
+                                <label for="builder[% instance.layout.instance_id %]">Apply the following filters to records in the selected table::</label>
+                                <div id="builder[% instance.layout.instance_id %]"></div>
+                        </div>
+                    </div>
+                [% END %]
+                <input id="filter" type="hidden" name="filter" value="[% column.filter.as_json | html_entity %]">
+            [% ELSE %]
+                <div class="alert alert-info">
+                    No other instances are available to select data from
+                </div>
+            [% END %]
+        </div>
+        <div id="divfile"
+            [% IF column.type != "file" %]
+                style="display:none"
+            [% END %]
+            >
+            <h4>Document field options</h4>
+            <div class="form-group">
+                <label for="filesize">Set maximum file size (KB): (Leave blank for no limit)</label>
+                <input type="text" class="form-control" name="filesize" id="filesize"
+                    value="[% column.filesize %]" placeholder="Leave blank for no limit">
+            </div>
+        </div>
+        <div id="divstring"
+                [% IF column.type != "string" %]
+                    style="display:none"
+                [% END %]
+            >
+            <h4>Text field options</h4>
+            <div class="form-group">
+                <div class="checkbox">
+                    <label>
+                        <input id="textbox" type="checkbox" name="textbox" [% IF column.textbox %]checked[% END %]>Make this a multi-line text box
+                    </label>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="force_regex">Require the field value to be in a particular format: [% whats_this('modalhelp_force_regex') %]</label>
+                <input id="force_regex" class="form-control" type="text" name="force_regex" value="[% column.force_regex | html_entity %]">
+            </div>
+        </div>
+        <div id="divdate"
+                [% IF column.type != "date" AND column.type != "daterange" %]
+                    style="display:none"
+                [% END %]
+            >
+            <div class="form-group">
+                <label for="show_datepicker">Show date picker:</label>
+                <div class="checkbox">
+                    <label>
+                        <input id="show_datepicker" type="checkbox" name="show_datepicker" [% IF NOT column.show_datepicker.defined OR column.show_datepicker %]checked[% END %]>Show date picker pop-up
+                    </label>
+                </div>
+            </div>
+        </div>
+        <div id="divcalc"
+            [% IF column.type != "calc" %]
+                style="display:none"
+            [% END %]
+            >
+            <p>
+                A calculated value field automatically generates values based on the values
+                of other fields. You define your calculation using the Lua programming language.
+            </p>
+            <div class="form-group">
+                <label for="return_type">Return value conversion:</label>
+                <select class="form-control" name="return_type">
+                    <option value="string" [% IF column.return_type == "string" %]selected[% END %]>String</option>
+                    <option value="date" [% IF column.return_type == "date" %]selected[% END %]>Date</option>
+                    <option value="integer" [% IF column.return_type == "integer" %]selected[% END %]>Integer</option>
+                    <option value="numeric" [% IF column.return_type == "numeric" %]selected[% END %]>Decimal</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="code_calc">Calculation: [% whats_this('helpcalc') %]</label>
+                <textarea class="form-control monospace" id="code_calc" name="code_calc" rows="10">[% column.code | html_entity %]</textarea>
+            </div>
+            <div class="form-group">
+                <label for="no_alerts_calc">Alerts:</label>
+                <div class="checkbox">
+                    <label>
+                        <input id="no_alerts_calc" type="checkbox" name="no_alerts_calc" checked>Do not send alerts when making this update
+                            (alerts will still be sent when records are subsequently edited individually)
+                    </label>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="no_cache_update">Status updates:</label>
+                <div class="radio">
+                    <label>
+                        <input type="radio" name="no_cache_update" value="0" checked>Update all existing values immediately
+                    </label>
+                </div>
+                <div class="radio">
+                    <label>
+                        <input type="radio" name="no_cache_update" value="1">Do not immediately update all existing values
+                            (values will be updated overnight instead)
+                    </label>
+                </div>
+            </div>
+        </div>
+        <div id="divrag"
+            [% IF column.type != "rag" %]
+                style="display:none"
+            [% END %]
+            >
+            <p>
+                Use a RAG field to automatically generate red, amber or green indicators based on
+                the values of other fields. You set the conditions for the RAG status using the
+                Lua programming language.
+            </p>
+            <div class="form-group">
+                <label for="code_rag">Conditions for this RAG status field: [% whats_this('helpcalc') %]</label>
+                <textarea class="form-control monospace" id="code_rag" name="code_rag" rows="10">[% column.code | html_entity %]</textarea>
+            </div>
+            <div class="form-group">
+                <label for="no_alerts_calc">Alerts:</label>
+                <div class="checkbox">
+                    <label>
+                        <input id="no_alerts_calc" type="checkbox" name="no_alerts_calc" checked>Do not send alerts when making this update
+                            (alerts will still be sent when records are subsequently edited individually)
+                    </label>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="no_cache_update">Status updates:</label>
+                <div class="radio">
+                    <label>
+                        <input type="radio" name="no_cache_update" value="0" checked>Update all existing values immediately
+                    </label>
+                </div>
+                <div class="radio">
+                    <label>
+                        <input type="radio" name="no_cache_update" value="1">Do not immediately update all existing values
+                            (values will be updated overnight instead)
+                    </label>
+                </div>
+            </div>
+        </div>
+    </div>
+[% END %]
+
+
+[% BLOCK edit_field %]
+    [% IF column.type == "rag" OR column.type == "calc" %][% noragcalc = 'style="display:none"' %][% END %]
+
+    <h2>[% IF column.id %]Edit field[% ELSE %]Add a field to [% instance_name | html %][% END %]</h2>
+
+    [% PROCESS edit_field_left_column %]
+    [% PROCESS edit_field_right_column %]
 [% END %]
 
 [% BLOCK list_fields %]
@@ -641,6 +648,7 @@
                 $('#configure-permissions').on('click', function () {
                     $(this).attr('hidden', '');
                     $('#permission-configuration').removeAttr('hidden');
+                    $(this).parent().find('h4').focus();
                 }); 
 
                 $('#sortable').sortable({
@@ -817,15 +825,35 @@
     </script>
 [% END %]
 
-<div class="manage-fields">
-    [% 
-        IF column.defined;
-            PROCESS edit_field;
-        ELSE;
-            PROCESS manage_fields;
-        END;
+<form method="post">
+[% IF column.id %]
+    <input type="hidden" name="id" value="[% column.id %]">
+[% END %]
 
-        PROCESS layout_modals;
-        PROCESS javascript;
-    %]
-</div>
+    <section class="manage-fields row">
+        [% 
+            IF column.defined;
+                PROCESS edit_field;
+            ELSE;
+                PROCESS list_fields;
+            END;
+
+        %]
+    </section>
+
+    <div class="row controls">
+        <div class="col-md-12">
+            <button type="submit" id="submit_save" name="submit" value="submit" class="btn btn-primary">[% IF column.id %]Save[% ELSE %]Save[% END %]</button>
+        [% IF column.id %]
+            <a href="/layout/" class="btn btn-default">Cancel</a>
+            <a href="" class="btn btn-default" data-toggle="modal" data-target="#myModal">Delete</a>
+        [% END %]
+        </div>
+    </div>
+</form>
+
+[%
+    PROCESS layout_modals;
+    PROCESS javascript;
+%]
+

--- a/views/layouts/main.tt
+++ b/views/layouts/main.tt
@@ -78,12 +78,12 @@
 
     </head>
 
-    <body>
+    <body data-page="[% page %]">
         <div id="wrapper">
         [% IF header AND NOT page_as_mech %]
             <p class="text-center">[% header %]</p>
         [% END %]
-        <div class="container-fluid">
+        <div class="container-fluid [% page %]">
             [% UNLESS page == "login" OR page == "invalidsite" OR page_as_mech %]
                 <div class="navbar navbar-default" role="navigation">
                     <div class="collapse navbar-collapse" id="main-navbar">

--- a/views/snippets/layout_modals.tt
+++ b/views/snippets/layout_modals.tt
@@ -1,0 +1,128 @@
+[% BLOCK layout_modals %]
+    <div class="modal fade" id="helprag" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">RAG values</h4>
+                </div>
+                <div class="modal-body">
+                    <p>[% global.helptext.layout_rag %]</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+
+    <!-- Modal -->
+    <div class="modal fade" id="helpcalc" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Calculated and RAG values</h4>
+                </div>
+                <div class="modal-body">
+                    <p>[% global.helptext.layout_calc %]</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+   <!-- Modal -->
+    <div class="modal fade" id="modalhelp_match" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Matching field values</h4>
+                </div>
+                <div class="modal-body">
+                    <p>[% global.helptext.layout_match %]</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+
+    <!-- Modal -->
+    <div class="modal fade" id="modalhelp_name_short" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Field short names</h4>
+                </div>
+                <div class="modal-body">
+                    <p>[% global.helptext.name_short %]</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+   <!-- Modal -->
+
+    <div class="modal fade" id="modalhelp_groups" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Permissions</h4>
+                </div>
+                <div class="modal-body">
+                    <p>[% global.helptext.layout_groups %]</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+   <!-- Modal -->
+
+    <div class="modal fade" id="modalhelp_force_regex" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Force input format</h4>
+                </div>
+                <div class="modal-body">
+                    <p>[% global.helptext.force_regex %]</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+   <!-- Modal -->
+    <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <form role="form" method="post" enctype="multipart/form-data">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalLabel">Are you sure?</h4>
+                </div>
+                <div class="modal-body">
+                    <p>Are you sure you want to delete this item? Deleting an item will also delete all its associated data.</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" name="delete" value="delete" class="btn btn-primary">Confirm deletion</button>
+                </div>
+                </form>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
+[% END %]
+

--- a/views/snippets/layout_permissions.tt
+++ b/views/snippets/layout_permissions.tt
@@ -101,7 +101,7 @@
         [% END %]
 
         [% IF column.permissions.size %]
-        <section class="permissions">
+        <section id="current-permissions">
             <h4>Groups that can read:</h4>
             [% group_list(column.group_summary('read')) %]
 

--- a/views/snippets/layout_permissions.tt
+++ b/views/snippets/layout_permissions.tt
@@ -43,6 +43,49 @@
     </li>
 [% END %]
 
+[% BLOCK _permissions_for_group %]
+    <div class="form-group">
+        <input data-permission-class="read" type="checkbox" id="[% group %]-can_read" 
+            name="read" [% column.group_has(group, 'read') && 'checked' %]>
+        <label for="[% group %]-can_read">Users have read access to this field</label>
+    </div>
+
+     <div class="form-group permission write-new">
+        <input data-permission-class="write-new-no-approval" type="checkbox" id="[% group %]-can_write_new_no_approval" 
+            name="write_new_no_approval" [% column.group_has(group, 'write_new_no_approval') && 'checked' %]>
+        <label for="[% group %]-can_write_new_no_approval">Values can be written to new records</label>
+
+        <div class="form-group permission">
+            <input data-permission-class="write-new" type="checkbox" id="[% group %]-can_write_new" 
+                name="write_new" [% column.group_has(group, 'write_new') && 'checked' %]>
+            <label for="[% group %]-can_write_new">Values for new records need approval</label>
+        </div>
+    </div>
+
+    <div class="form-group permission modify-existing">
+        <input data-permission-class="write-existing-no-approval" type="checkbox" id="[% group %]-can_write_existing_no_approval" 
+            name="write_existing_no_approval" [% column.group_has(group, 'write_existing_no_approval') && 'checked' %]>
+        <label for="[% group %]-can_write_existing_no_approval">Existing values can be modified</label>
+
+        <div class="form-group permission">
+            <input data-permission-class="write-existing" type="checkbox" id="[% group %]-can_write_existing" name="write_existing" [% column.group_has(group, 'write_existing') && 'checked' %]>
+            <label for="[% group %]-can_write_existing">Modifications need approval</label>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <input data-permission-class="approve-new" type="checkbox" id="[% group %]-can_approve_new" 
+            name="approve_new" [% column.group_has(group, 'approve_new') && 'checked' %]>
+        <label for="[% group %]-can_approve_new">Users can approve new values</label>
+    </div>
+
+    <div class="form-group">
+        <input data-permission-class="approve-existing" type="checkbox" id="[% group %]-can_approve_existing" 
+            name="approve_existing" [% column.group_has(group, 'approve_existing') && 'checked' %]>
+        <label for="[% group %]-can_approve_existing">Users can approve modifications</label>
+    </div>
+[% END %]
+
 [% BLOCK _permission_configuration %]
     <h4 tabindex="-1">Add permissions</h4>
 
@@ -103,59 +146,46 @@
     %]
 
         [% IF column.permissions.size %]
-        <section id="current-permissions">
-            <h5>Current permissions</h5>
-            <div class="legend">
-                <h6>Abbreviations</h6>
-                <dl>
-                    <dt>R:</dt>
-                    <dd>Read values</dd>
-
-                    <dt>C:</dt>
-                    <dd>Enter values for new records without requiring approval</dd>
-
-                    <dt>E:</dt>
-                    <dd>Edit values of existing records without requiring approval</dd>
-
-                    <dt>C+A:</dt>
-                    <dd>Write values for new records</dd>
-
-                    <dt>E+A:</dt>
-                    <dd>Edit values of existing records</ds>
-
-                    <dt>A(N):</dt>
-                    <dd>Approve values in new records</dd>
-
-                    <dt>A(E):</dt>
-                    <dd>Approve changes in existing records</dd>
-                </dl>
-            </div>
+        <div id="current-permissions">
             <ul>
                 [% FOREACH group IN groups.all %]
                     [% group_id = group.id %]
                     [% permissions = column.permissions.$group_id %]
                     [% NEXT UNLESS permissions %]
-                <li data-group-id="[% group_id %]" class="permission">
+                    
+                    [% permission_classes = '' %]
+                    
+                    [% FOREACH permission IN permissions %]
+                        [% short = permission.short %]
+                        [% permission_classes = permission_classes _ ' ' _ 'permission-' _ short.replace('_','-') %]
+                    [% END %]
+ 
+                <li data-group-id="[% group_id %]" class="permission [% permission_classes %]">
                     <div class="summary">
                         <h6 class="group-name">[% group.name %]</h6>
-                        <span class="configuration">
+                        <div class="configuration">
                             [% FOREACH permission IN permissions %]
                             [% short = permission.short %]
                             [% abbr = permission_mapping.$short %]
-                            <span tabindex="0" class="abbreviation" role="tooltip" aria-describedby="[% group_id %]_permission_[% short %]">
+                            [% short_class = short.replace('_','-') %]
+                            <span tabindex="0" class="abbreviation abbreviation-[% short_class %]" 
+                                role="tooltip" aria-describedby="[% group_id %]_permission_[% short %]">
                                 [% abbr %]
                             </span>
                             <span id="[% group_id %]_permission_[% short %]" class="visually-hidden tooltip">[% permission.long | html %]</span>
                             [% END %]
-                        </span>
+                        </div>
                     </div>
-                    <button type="button" class="pull-right btn btn-sm btn-primary trigger" aria-expanded="false">Change &rarr;</button>
+                    <button type="button" class="edit pull-right btn btn-sm btn-primary trigger" aria-expanded="false">Change &rarr;</button>
                     <div class="expandable">
+                        <h7 tabindex="-1">Change permissions</h7>
+                        [% PROCESS _permissions_for_group group = group_id %]
+                        <button type="button" class="ok btn btn-sm btn-primary">Ok</button>
                     </div>
                 </li>
                 [% END %]
             </ul>
-        </section>
+        </div>
 
         [% END %]
     [% ELSE # no column %]

--- a/views/snippets/layout_permissions.tt
+++ b/views/snippets/layout_permissions.tt
@@ -39,14 +39,12 @@
                     <label for="[% perm %]-can_approve_edits">Modifications need approval</label>
                 </div>
             </div>
-
-                
         </section>
     </li>
 [% END %]
 
 [% BLOCK _permission_configuration %]
-    <h4 tabindex="-1">Configure permissions</h4>
+    <h4 tabindex="-1">Add permissions</h4>
 
     <p>Here you can create rules to define the access of group members to this field.</p>
     <p>No user has access to this field, unless explicitly defined.</p>
@@ -60,7 +58,10 @@
             [% END %]
         </ul>
         [% END %]
-        <button type="button" class="btn btn-default add-permission">Add rule</button>
+        <button id="add-permission-rule" type="button" class="btn btn-default add-permission">Add rule</button>
+        <script type="html/template" id="permission-rule-template">
+        </script>
+
     [% ELSE %]
         <p>No groups have been created yet. <a href="/group">Create a group.</a></p>
     [% END %]
@@ -89,16 +90,73 @@
             </ul>
         [% END %]
 
+    [% 
+        permission_mapping = {
+            read                       => 'R',
+            write_new                  => 'C+A',
+            write_existing             => 'E+A',
+            approve_new                => 'A(N)',
+            approve_existing           => 'A(E)',
+            write_new_no_approval      => 'C',
+            write_existing_no_approval => 'E'
+        }
+    %]
+
         [% IF column.permissions.size %]
         <section id="current-permissions">
-            <h4>Groups that can read:</h4>
-            [% group_list(column.group_summary('read')) %]
+            <h5>Current permissions</h5>
+            <div class="legend">
+                <h6>Abbreviations</h6>
+                <dl>
+                    <dt>R:</dt>
+                    <dd>Read values</dd>
 
-            <h4>Groups that can write new values:</h4>
-            [% group_list(column.group_summary('write_new')) %]
+                    <dt>C:</dt>
+                    <dd>Enter values for new records without requiring approval</dd>
 
-            <h4>Groups that can write existing values:</h4>
-            [% group_list(column.group_summary('write_existing')) %]
+                    <dt>E:</dt>
+                    <dd>Edit values of existing records without requiring approval</dd>
+
+                    <dt>C+A:</dt>
+                    <dd>Write values for new records</dd>
+
+                    <dt>E+A:</dt>
+                    <dd>Edit values of existing records</ds>
+
+                    <dt>A(N):</dt>
+                    <dd>Approve values in new records</dd>
+
+                    <dt>A(E):</dt>
+                    <dd>Approve changes in existing records</dd>
+                </dl>
+            </div>
+            <ul>
+                [% FOREACH group IN groups.all %]
+                    [% group_id = group.id %]
+                    [% permissions = column.permissions.$group_id %]
+                    [% NEXT UNLESS permissions %]
+                <li data-group-id="[% group_id %]" class="permission">
+                    <div class="summary">
+                        <h6 class="group-name">[% group.name %]</h6>
+                        <span class="configuration">
+                            [% FOREACH permission IN permissions %]
+                            [% short = permission.short %]
+                            [% abbr = permission_mapping.$short %]
+                            <span tabindex="0" class="abbreviation" role="tooltip" aria-describedby="[% group_id %]_permission_[% short %]">
+                                <span style="font-weight: bold" aria-hidden="true">[</span>
+                                [% abbr %]
+                                <span style="font-weight: bold" aria-hidden="true">]</span>
+                            </span>
+                            <span id="[% group_id %]_permission_[% short %]" class="visually-hidden tooltip">[% permission.long | html %]</span>
+                            [% END %]
+                        </span>
+                    </div>
+                    <button type="button" class="pull-right btn btn-sm btn-primary trigger" aria-expanded="false">Change &rarr;</button>
+                    <div class="expandable">
+                    </div>
+                </li>
+                [% END %]
+            </ul>
         </section>
 
         [% END %]
@@ -108,7 +166,7 @@
     [% END %]
 
     [% IF groups.all.size %]
-        <button id="configure-permissions" type="button" class="btn btn-default">Configure permissions</button>
+        <button id="configure-permissions" type="button" class="btn btn-default">Add permissions</button>
         <section id="permission-configuration" hidden>
             [% PROCESS _permission_configuration %]
         </section>

--- a/views/snippets/layout_permissions.tt
+++ b/views/snippets/layout_permissions.tt
@@ -143,9 +143,7 @@
                             [% short = permission.short %]
                             [% abbr = permission_mapping.$short %]
                             <span tabindex="0" class="abbreviation" role="tooltip" aria-describedby="[% group_id %]_permission_[% short %]">
-                                <span style="font-weight: bold" aria-hidden="true">[</span>
                                 [% abbr %]
-                                <span style="font-weight: bold" aria-hidden="true">]</span>
                             </span>
                             <span id="[% group_id %]_permission_[% short %]" class="visually-hidden tooltip">[% permission.long | html %]</span>
                             [% END %]

--- a/views/snippets/layout_permissions.tt
+++ b/views/snippets/layout_permissions.tt
@@ -1,108 +1,101 @@
-[% MACRO render_perm(perm, groups, column) BLOCK;
-    FOREACH group IN groups;
-        IF group.id == perm;
-            perm_group = group;
-            LAST;
-        END;
-    END;
+[% 
+    permission_mapping = {
+        'read'                       => 'R',
+        'write_new'                  => 'C+A',
+        'write_existing'             => 'E+A',
+        'approve_new'                => 'A(N)',
+        'approve_existing'           => 'A(E)',
+        'write_new_no_approval'      => 'C',
+        'write_existing_no_approval' => 'E'
+    }
+
+    permission_inputs = {
+        'read'                        => 'Values can be read',
+        'write_new_no_approval'       => 'Values can be written to new records',
+        'write_new'                   => 'Values for new records need approval',
+        'write_existing_no_approval'  => 'Values for existing records can be modified',
+        'write_existing'              => 'Modifications to existing records need approval',
+        'approve_new'                 => 'Values for new records can be approved',
+        'approve_existing'            => 'Modifications to existing records can be approved'
+    } 
 %]
-    <li data-group-id="[% perm %]">
-        <section class="permission-rule">
-            <h5 class="clearfix">
-                Group: [% group.name %]
-                <button type="button" class="btn btn-sm btn-default pull-right" data-perm-id="[% perm %]">Delete rule</button>
-            </h5>
-
-            <p>Members of this group will have the following access rights:</p>
-
-            <div class="form-group">
-                <input type="checkbox" id="can_read" name="read" [% column.group_has(perm, 'read') && 'checked' %]>
-                <label for="can_read">Users have read access to this field</label>
-            </div>
-
-             <div class="form-group permission write-new">
-                <input type="checkbox" id="[% perm %]-can_write_new" name="write_new" [% column.group_has(perm, 'write_new') && 'checked' %]>
-                <label for="[% perm %]-can_write_new">Values can be written to new records</label>
-
-                <div class="form-group permission">
-                    <input type="checkbox" id="[% perm %]-can_approve_new" name="approve_new" [% column.group_has(perm, 'approve_new') && 'checked' %]>
-                    <label for="[% perm %]-can_approve_new">Values for new records need approval</label>
-                </div>
-            </div>
-
-            <div class="form-group permission modify-existing">
-                <input type="checkbox" id="[% perm %]-can_edit_existing" name="write_existing" [% column.group_has(perm, 'write_existing') && 'checked' %]>
-                <label for="[% perm %]-can_edit_existing">Existing values can be modified</label>
-
-                <div class="form-group permission">
-                    <input type="checkbox" id="[% perm %]-can_approve_edits" name="approve_existing" [% column.group_has(perm, 'approve_existing') && 'checked' %]>
-                    <label for="[% perm %]-can_approve_edits">Modifications need approval</label>
-                </div>
-            </div>
-        </section>
-    </li>
-[% END %]
 
 [% BLOCK _permissions_for_group %]
-    <div class="form-group">
-        <input data-permission-class="read" type="checkbox" id="[% group %]-can_read" 
-            name="read" [% column.group_has(group, 'read') && 'checked' %]>
-        <label for="[% group %]-can_read">Users have read access to this field</label>
-    </div>
-
-     <div class="form-group permission write-new">
-        <input data-permission-class="write-new-no-approval" type="checkbox" id="[% group %]-can_write_new_no_approval" 
-            name="write_new_no_approval" [% column.group_has(group, 'write_new_no_approval') && 'checked' %]>
-        <label for="[% group %]-can_write_new_no_approval">Values can be written to new records</label>
-
-        <div class="form-group permission">
-            <input data-permission-class="write-new" type="checkbox" id="[% group %]-can_write_new" 
-                name="write_new" [% column.group_has(group, 'write_new') && 'checked' %]>
-            <label for="[% group %]-can_write_new">Values for new records need approval</label>
+    [% MACRO permission_input(name, label, group, nested) BLOCK %]
+        <div class="form-group">
+            <input data-permission-class="[% name.replace('_','-') %]" type="checkbox" id="permission_[% name %]_[% group %]" 
+                name="permission_[% name %]_[% group %]" [% column.group_has(group, name) ? 'checked' : '' %]>
+            <label for="permission_[% name %]_[% group %]">[% label %]</label>
+            [% nested %]
         </div>
-    </div>
+    [% END %]
 
-    <div class="form-group permission modify-existing">
-        <input data-permission-class="write-existing-no-approval" type="checkbox" id="[% group %]-can_write_existing_no_approval" 
-            name="write_existing_no_approval" [% column.group_has(group, 'write_existing_no_approval') && 'checked' %]>
-        <label for="[% group %]-can_write_existing_no_approval">Existing values can be modified</label>
+    [% write_new      = permission_input('write_new'     , permission_inputs.write_new)      %]
+    [% write_existing = permission_input('write_existing', permission_inputs.write_existing) %]
 
-        <div class="form-group permission">
-            <input data-permission-class="write-existing" type="checkbox" id="[% group %]-can_write_existing" name="write_existing" [% column.group_has(group, 'write_existing') && 'checked' %]>
-            <label for="[% group %]-can_write_existing">Modifications need approval</label>
-        </div>
-    </div>
+    [% permission_input('read', permission_inputs.read) %]
 
-    <div class="form-group">
-        <input data-permission-class="approve-new" type="checkbox" id="[% group %]-can_approve_new" 
-            name="approve_new" [% column.group_has(group, 'approve_new') && 'checked' %]>
-        <label for="[% group %]-can_approve_new">Users can approve new values</label>
-    </div>
+    [% permission_input('write_new_no_approval', permission_inputs.write_new_no_approval, '', write_new) %]
+    [% permission_input('write_existing_no_approval', permission_inputs.write_existing_no_approval, '', write_existing) %]
 
-    <div class="form-group">
-        <input data-permission-class="approve-existing" type="checkbox" id="[% group %]-can_approve_existing" 
-            name="approve_existing" [% column.group_has(group, 'approve_existing') && 'checked' %]>
-        <label for="[% group %]-can_approve_existing">Users can approve modifications</label>
-    </div>
+    [% permission_input('approve_new', permission_inputs.approve_new) %]
+    [% permission_input('approve_existing', permission_inputs.approve_existing) %]
+[% END %]
+
+[% BLOCK _permission_rule_template %]
+    <script id="permission-rule-template" type="html/template">
+            <li data-group-id="" class="permission [% permission_classes %]">
+                <div class="summary">
+                    <h6 class="group-name"></h6>
+                    <div class="configuration">
+                        [% FOREACH permission IN permissions %]
+                        [% short = permission.short %]
+                        [% abbr = permission_mapping.$short %]
+                        [% short_class = short.replace('_','-') %]
+                        <span tabindex="0" class="abbreviation abbreviation-[% short_class %]" 
+                            role="tooltip" aria-describedby="-permission-[% short %]">
+                            [% abbr %]
+                        </span>
+                        <span id="[% group_id %]_permission_[% short %]" class="visually-hidden tooltip">[% permission.long | html %]</span>
+                        [% END %]
+                    </div>
+                </div>
+                <button type="button" class="delete pull-right btn btn-sm btn-primary trigger">Delete</button>
+                <button type="button" class="edit pull-right btn btn-sm btn-primary trigger" aria-expanded="false">Change &rarr;</button>
+                <div class="expandable">
+                    <h7 tabindex="-1">Change permissions</h7>
+                    [% PROCESS _permissions_for_group %]
+                    <button type="button" class="ok btn btn-sm btn-primary">Ok</button>
+                </div>
+            </li>
+    </script>
 [% END %]
 
 [% BLOCK _permission_configuration %]
     <h4 tabindex="-1">Add permissions</h4>
 
-    <p>Here you can create rules to define the access of group members to this field.</p>
-    <p>No user has access to this field, unless explicitly defined.</p>
-
     [% IF groups.all.size %]
-        [% existing_perms = column.permissions.keys %]
-        [% IF existing_perms.size %]
-        <ul>
-            [% FOREACH perm IN existing_perms %]
-               [% render_perm(perm, groups.all, column) %]
+        <section class="permission-rule">
+            <h5>Add permissions</h5>
+
+            <label for="select-permission-group">
+                Group:
+            </label>
+            <select id="select-permission-group">
+            [% FOREACH group IN groups.all %]
+                <option class="permission-group-[% group.id %]" value="[% group.id %]">[% group.name %]</option>
             [% END %]
-        </ul>
-        [% END %]
-        <button id="add-permission-rule" type="button" class="btn btn-default add-permission">Add rule</button>
-        <script type="html/template" id="permission-rule-template">
+            </select>
+
+            <p>Members of this group will have the following access rights:</p>
+
+            [% PROCESS _permissions_for_group %]
+
+            <button id="add-permission-rule" type="button" class="btn btn-default add-permission">Add rule</button>
+            <button id="cancel-permission-rule" type="button" class="btn btn-default cancel-permission">Cancel</button>
+        </section>
+    </li>
+
         </script>
 
     [% ELSE %]
@@ -112,7 +105,11 @@
 [% END %]
 
 [% BLOCK layout_permissions %]
-<section id="permissions">
+    [% existing_perms = column.permissions.keys %]
+
+    [% PROCESS _permission_rule_template %]
+
+<section id="permissions" class="[% FOREACH p IN existing_perms; 'permission-group-' _ p _ ' '; END %]">
     <h4>Permissions [% whats_this('modalhelp_groups') %]</h4>
     [% IF column.id %]
 
@@ -133,20 +130,8 @@
             </ul>
         [% END %]
 
-    [% 
-        permission_mapping = {
-            read                       => 'R',
-            write_new                  => 'C+A',
-            write_existing             => 'E+A',
-            approve_new                => 'A(N)',
-            approve_existing           => 'A(E)',
-            write_new_no_approval      => 'C',
-            write_existing_no_approval => 'E'
-        }
-    %]
-
         [% IF column.permissions.size %]
-        <div id="current-permissions">
+        <div id="current-permissions" aria-live="polite">
             <ul>
                 [% FOREACH group IN groups.all %]
                     [% group_id = group.id %]
@@ -176,6 +161,7 @@
                             [% END %]
                         </div>
                     </div>
+                    <button type="button" class="delete pull-right btn btn-sm btn-primary trigger">Delete</button>
                     <button type="button" class="edit pull-right btn btn-sm btn-primary trigger" aria-expanded="false">Change &rarr;</button>
                     <div class="expandable">
                         <h7 tabindex="-1">Change permissions</h7>
@@ -195,6 +181,13 @@
 
     [% IF groups.all.size %]
         <button id="configure-permissions" type="button" class="btn btn-default">Add permissions</button>
+        <style>
+        [% FOREACH group IN groups.all %]
+            #permissions.permission-group-[% group.id %] option.permission-group-[% group.id %] {
+                display: none;
+            }
+        [% END %]
+        </style>
         <section id="permission-configuration" hidden>
             [% PROCESS _permission_configuration %]
         </section>

--- a/views/snippets/layout_permissions.tt
+++ b/views/snippets/layout_permissions.tt
@@ -1,0 +1,101 @@
+[% MACRO render_perm(perm, groups, column) BLOCK;
+    FOREACH group IN groups;
+        IF group.id == perm;
+            perm_group = group;
+            LAST;
+        END;
+    END;
+%]
+    <li data-group-id="[% perm %]">
+        <h4>[% group.name %]</h4>
+
+        <div class="form-group">
+            <input type="checkbox" id="can_read" name="read" [% column.group_has(perm, 'read') && 'checked' %]>
+            <label for="can_read">Read</label>
+        </div>
+
+         <div class="form-group">
+            <input type="checkbox" id="can_write_new" name="write_new" [% column.group_has(perm, 'write_new') && 'checked' %]>
+            <label for="can_write_new">Write values to new records</label>
+        </div>
+
+        <div class="form-group">
+            <input type="checkbox" id="can_edit_existing" name="write_existing" [% column.group_has(perm, 'write_existing') && 'checked' %]>
+            <label for="can_edit_existing">Edit existing values</label>
+        </div>
+
+        <button type="button" class="btn btn-sm btn-default" data-perm-id="[% perm %]">Delete rule</button>
+    </li>
+[% END %]
+
+[% BLOCK _permission_configuration %]
+    <h4>Configure permissions</h4>
+
+    <p>Here you can create rules to define the access of group members to this field.</p>
+    <p>No user has access to this field, unless explicitly defined.</p>
+
+    [% IF groups.all.size %]
+        [% existing_perms = column.permissions.keys %]
+        [% IF existing_perms.size %]
+        <ul>
+            [% FOREACH perm IN existing_perms %]
+               [% render_perm(perm, groups.all, column) %]
+            [% END %]
+        </ul>
+        [% END %]
+        <button type="button" class="btn btn-default add-permission">Add access rule</button>
+    [% ELSE %]
+        <p>No groups have been created yet. <a href="/group">Create a group.</a></p>
+    [% END %]
+
+[% END %]
+
+[% BLOCK layout_permissions %]
+    <h3>Permissions [% whats_this('modalhelp_groups') %]</h3>
+    [% IF column.id %]
+
+        [% IF NOT column.permissions.size %]
+            <p>Access must be granted to this field before anyone (including you) can view and edit data in it.</p>
+            [% IF groups.all.size %]
+                <p>To give access, a group must be assigned to it using the buttons below:</p>
+            [% ELSE %]
+                <p>Groups are used to assign access. You must first <a href="/group">create a group</a></p>
+            [% END %]
+        [% END %]
+
+        [% IF column.permissions.size %]
+        <section class="permissions">
+            <h4>Groups that can read:</h4>
+            <ul>
+                [% FOREACH g IN column.group_summary('read') %]
+                <li>[% g %]</li>
+                [% END %]
+            </ul>
+
+            <h4>Groups that can write new values:</h4>
+            <ul>
+                [% FOREACH g IN column.group_summary('write_new') %]
+                <li>[% g %]</li>
+                [% END %]
+            </ul>
+
+            <h4>Groups that can write existing values:</h4>
+            <ul>
+                [% FOREACH g IN column.group_summary('write_existing') %]
+                <li>[% g %]</li>
+                [% END %]
+            </ul>
+        </sections>
+        [% END %]
+    [% ELSE # no column %]
+        [% # TODO: symptom of system. Fix. %]
+        <p>Please save the field before adding permissions</p>
+    [% END %]
+
+    [% IF groups.all.size %]
+        <button id="configure-permissions" type="button" class="btn btn-default">Configure permissions</button>
+        <section id="permission-configuration">
+            [% PROCESS _permission_configuration %]
+        </section>
+    [% END %]
+[% END %]

--- a/views/snippets/layout_permissions.tt
+++ b/views/snippets/layout_permissions.tt
@@ -74,6 +74,7 @@
 [% END %]
 
 [% BLOCK layout_permissions %]
+<section id="layout_permissions">
     <h3>Permissions [% whats_this('modalhelp_groups') %]</h3>
     [% IF column.id %]
 
@@ -118,4 +119,5 @@
             [% PROCESS _permission_configuration %]
         </section>
     [% END %]
+</section>
 [% END %]

--- a/views/snippets/layout_permissions.tt
+++ b/views/snippets/layout_permissions.tt
@@ -7,47 +7,52 @@
     END;
 %]
     <li data-group-id="[% perm %]">
-        <h5>[% group.name %]</h5>
-        <button type="button" class="btn btn-sm btn-default" data-perm-id="[% perm %]">Delete rule</button>
+        <h5>
+            [% group.name %]
+            <button type="button" class="btn btn-sm btn-default" data-perm-id="[% perm %]">Delete rule</button>
+        </h5>
 
         <section>
             <h6>Access</h6>
-            <div class="form-group">
-                <input type="checkbox" id="can_read" name="read" [% column.group_has(perm, 'read') && 'checked' %]>
-                <label for="can_read">Read</label>
-            </div>
+            <div class="row">
+                <div class="form-group col-md-3">
+                    <input type="checkbox" id="can_read" name="read" [% column.group_has(perm, 'read') && 'checked' %]>
+                    <label for="can_read">Read</label>
+                </div>
 
-             <div class="form-group">
-                <input type="checkbox" id="[% perm %]-can_write_new" name="write_new" [% column.group_has(perm, 'write_new') && 'checked' %]>
-                <label for="[% perm %]-can_write_new">Write values to new records</label>
-            </div>
+                 <div class="form-group col-md-3">
+                    <input type="checkbox" id="[% perm %]-can_write_new" name="write_new" [% column.group_has(perm, 'write_new') && 'checked' %]>
+                    <label for="[% perm %]-can_write_new">Write values to new records</label>
+                </div>
 
-            <div class="form-group">
-                <input type="checkbox" id="[% perm %]-can_edit_existing" name="write_existing" [% column.group_has(perm, 'write_existing') && 'checked' %]>
-                <label for="[% perm %]-can_edit_existing">Edit existing values</label>
+                <div class="form-group col-md-3">
+                    <input type="checkbox" id="[% perm %]-can_edit_existing" name="write_existing" [% column.group_has(perm, 'write_existing') && 'checked' %]>
+                    <label for="[% perm %]-can_edit_existing">Edit existing values</label>
+                </div>
             </div>
         </section>
 
         <section>
             <h6>Approval</h6>
-            <div class="form-group">
-                <input type="checkbox" id="[% perm %]-can_create_without_approval" name="write_new_no_approval" [% column.group_has(perm, 'write_new_no_approval') && 'checked' %]>
-                <label for="[% perm %]-can_create_without_approval">No approval required for new records</label>
-            </div>
-            <div class="form-group">
-                <input type="checkbox" id="[% perm %]-can_edit_without_approval" name="write_existing_no_approval" [% column.group_has(perm, 'write_existing_no_approval') && 'checked' %]>
-                <label for="[% perm %]-can_edit_without_approval">No approval required for editing values</label>
-            </div>
-            <div class="form-group">
-                <input type="checkbox" id="[% perm %]-can_approve_new" name="approve_new" [% column.group_has(perm, 'approve_new') && 'checked' %]>
-                <label for="[% perm %]-can_approve_new">Approve new values</label>
-            </div>
-            <div class="form-group">
-                <input type="checkbox" id="[% perm %]-can_approve_edits" name="approve_existing" [% column.group_has(perm, 'approve_existing') && 'checked' %]>
-                <label for="[% perm %]-can_approve_edits">Approve edits</label>
+            <div class="row">
+                <div class="form-group col-md-6">
+                    <input type="checkbox" id="[% perm %]-can_create_without_approval" name="write_new_no_approval" [% column.group_has(perm, 'write_new_no_approval') && 'checked' %]>
+                    <label for="[% perm %]-can_create_without_approval">No approval required for new records</label>
+                </div>
+                <div class="form-group col-md-6">
+                    <input type="checkbox" id="[% perm %]-can_edit_without_approval" name="write_existing_no_approval" [% column.group_has(perm, 'write_existing_no_approval') && 'checked' %]>
+                    <label for="[% perm %]-can_edit_without_approval">No approval required for editing values</label>
+                </div>
+                <div class="form-group col-md-6">
+                    <input type="checkbox" id="[% perm %]-can_approve_new" name="approve_new" [% column.group_has(perm, 'approve_new') && 'checked' %]>
+                    <label for="[% perm %]-can_approve_new">Approve new values</label>
+                </div>
+                <div class="form-group col-md-6">
+                    <input type="checkbox" id="[% perm %]-can_approve_edits" name="approve_existing" [% column.group_has(perm, 'approve_existing') && 'checked' %]>
+                    <label for="[% perm %]-can_approve_edits">Approve edits</label>
+                </div>
             </div>
         </section>
-
     </li>
 [% END %]
 
@@ -74,7 +79,7 @@
 [% END %]
 
 [% BLOCK layout_permissions %]
-<section id="layout_permissions">
+<section id="permissions">
     <h3>Permissions [% whats_this('modalhelp_groups') %]</h3>
     [% IF column.id %]
 

--- a/views/snippets/layout_permissions.tt
+++ b/views/snippets/layout_permissions.tt
@@ -7,29 +7,52 @@
     END;
 %]
     <li data-group-id="[% perm %]">
-        <h4>[% group.name %]</h4>
-
-        <div class="form-group">
-            <input type="checkbox" id="can_read" name="read" [% column.group_has(perm, 'read') && 'checked' %]>
-            <label for="can_read">Read</label>
-        </div>
-
-         <div class="form-group">
-            <input type="checkbox" id="can_write_new" name="write_new" [% column.group_has(perm, 'write_new') && 'checked' %]>
-            <label for="can_write_new">Write values to new records</label>
-        </div>
-
-        <div class="form-group">
-            <input type="checkbox" id="can_edit_existing" name="write_existing" [% column.group_has(perm, 'write_existing') && 'checked' %]>
-            <label for="can_edit_existing">Edit existing values</label>
-        </div>
-
+        <h5>[% group.name %]</h5>
         <button type="button" class="btn btn-sm btn-default" data-perm-id="[% perm %]">Delete rule</button>
+
+        <section>
+            <h6>Access</h6>
+            <div class="form-group">
+                <input type="checkbox" id="can_read" name="read" [% column.group_has(perm, 'read') && 'checked' %]>
+                <label for="can_read">Read</label>
+            </div>
+
+             <div class="form-group">
+                <input type="checkbox" id="[% perm %]-can_write_new" name="write_new" [% column.group_has(perm, 'write_new') && 'checked' %]>
+                <label for="[% perm %]-can_write_new">Write values to new records</label>
+            </div>
+
+            <div class="form-group">
+                <input type="checkbox" id="[% perm %]-can_edit_existing" name="write_existing" [% column.group_has(perm, 'write_existing') && 'checked' %]>
+                <label for="[% perm %]-can_edit_existing">Edit existing values</label>
+            </div>
+        </section>
+
+        <section>
+            <h6>Approval</h6>
+            <div class="form-group">
+                <input type="checkbox" id="[% perm %]-can_create_without_approval" name="write_new_no_approval" [% column.group_has(perm, 'write_new_no_approval') && 'checked' %]>
+                <label for="[% perm %]-can_create_without_approval">No approval required for new records</label>
+            </div>
+            <div class="form-group">
+                <input type="checkbox" id="[% perm %]-can_edit_without_approval" name="write_existing_no_approval" [% column.group_has(perm, 'write_existing_no_approval') && 'checked' %]>
+                <label for="[% perm %]-can_edit_without_approval">No approval required for editing values</label>
+            </div>
+            <div class="form-group">
+                <input type="checkbox" id="[% perm %]-can_approve_new" name="approve_new" [% column.group_has(perm, 'approve_new') && 'checked' %]>
+                <label for="[% perm %]-can_approve_new">Approve new values</label>
+            </div>
+            <div class="form-group">
+                <input type="checkbox" id="[% perm %]-can_approve_edits" name="approve_existing" [% column.group_has(perm, 'approve_existing') && 'checked' %]>
+                <label for="[% perm %]-can_approve_edits">Approve edits</label>
+            </div>
+        </section>
+
     </li>
 [% END %]
 
 [% BLOCK _permission_configuration %]
-    <h4>Configure permissions</h4>
+    <h4 tabindex="-1">Configure permissions</h4>
 
     <p>Here you can create rules to define the access of group members to this field.</p>
     <p>No user has access to this field, unless explicitly defined.</p>
@@ -43,7 +66,7 @@
             [% END %]
         </ul>
         [% END %]
-        <button type="button" class="btn btn-default add-permission">Add access rule</button>
+        <button type="button" class="btn btn-default add-permission">Add rule</button>
     [% ELSE %]
         <p>No groups have been created yet. <a href="/group">Create a group.</a></p>
     [% END %]
@@ -63,29 +86,26 @@
             [% END %]
         [% END %]
 
+        [% MACRO group_list(groups) BLOCK %]
+            <ul>
+                [% FOREACH group IN groups %]
+                <li>[% group %]</li>
+                [% END %]
+            </ul>
+        [% END %]
+
         [% IF column.permissions.size %]
         <section class="permissions">
             <h4>Groups that can read:</h4>
-            <ul>
-                [% FOREACH g IN column.group_summary('read') %]
-                <li>[% g %]</li>
-                [% END %]
-            </ul>
+            [% group_list(column.group_summary('read')) %]
 
             <h4>Groups that can write new values:</h4>
-            <ul>
-                [% FOREACH g IN column.group_summary('write_new') %]
-                <li>[% g %]</li>
-                [% END %]
-            </ul>
+            [% group_list(column.group_summary('write_new')) %]
 
             <h4>Groups that can write existing values:</h4>
-            <ul>
-                [% FOREACH g IN column.group_summary('write_existing') %]
-                <li>[% g %]</li>
-                [% END %]
-            </ul>
-        </sections>
+            [% group_list(column.group_summary('write_existing')) %]
+        </section>
+
         [% END %]
     [% ELSE # no column %]
         [% # TODO: symptom of system. Fix. %]
@@ -94,7 +114,7 @@
 
     [% IF groups.all.size %]
         <button id="configure-permissions" type="button" class="btn btn-default">Configure permissions</button>
-        <section id="permission-configuration">
+        <section id="permission-configuration" hidden>
             [% PROCESS _permission_configuration %]
         </section>
     [% END %]

--- a/views/snippets/layout_permissions.tt
+++ b/views/snippets/layout_permissions.tt
@@ -23,30 +23,30 @@
 [% BLOCK _permissions_for_group %]
     [% MACRO permission_input(name, label, group, nested) BLOCK %]
         <div class="form-group">
-            <input data-permission-class="[% name.replace('_','-') %]" type="checkbox" id="permission_[% name %]_[% group %]" 
-                name="permission_[% name %]_[% group %]" [% column.group_has(group, name) ? 'checked' : '' %]>
-            <label for="permission_[% name %]_[% group %]">[% label %]</label>
+            <input data-permission-class="[% name.replace('_','-') %]" type="checkbox" id="permission_[% name %]_[% group.id %]" 
+                name="permission_[% name %]_[% group.id %]" [% column.group_has(group.id, name) ? 'checked' : '' %]>
+            <label for="permission_[% name %]_[% group.id %]">[% label %]</label>
             [% nested %]
         </div>
     [% END %]
 
-    [% write_new      = permission_input('write_new'     , permission_inputs.write_new)      %]
-    [% write_existing = permission_input('write_existing', permission_inputs.write_existing) %]
+    [% write_new      = permission_input('write_new'     , permission_inputs.write_new, group)      %]
+    [% write_existing = permission_input('write_existing', permission_inputs.write_existing, group) %]
 
-    [% permission_input('read', permission_inputs.read) %]
+    [% permission_input('read', permission_inputs.read, group) %]
 
-    [% permission_input('write_new_no_approval', permission_inputs.write_new_no_approval, '', write_new) %]
-    [% permission_input('write_existing_no_approval', permission_inputs.write_existing_no_approval, '', write_existing) %]
+    [% permission_input('write_new_no_approval', permission_inputs.write_new_no_approval, group, write_new) %]
+    [% permission_input('write_existing_no_approval', permission_inputs.write_existing_no_approval, group, write_existing) %]
 
-    [% permission_input('approve_new', permission_inputs.approve_new) %]
-    [% permission_input('approve_existing', permission_inputs.approve_existing) %]
+    [% permission_input('approve_new', permission_inputs.approve_new, group) %]
+    [% permission_input('approve_existing', permission_inputs.approve_existing, group) %]
 [% END %]
 
 [% BLOCK _permission_rule_template %]
     <script id="permission-rule-template" type="html/template">
             <li data-group-id="" class="permission [% permission_classes %]">
                 <div class="summary">
-                    <h6 class="group-name"></h6>
+                    <h6 tabindex="-1" class="group-name"></h6>
                     <div class="configuration">
                         [% FOREACH permission IN permissions %]
                         [% short = permission.short %]
@@ -63,7 +63,6 @@
                 <button type="button" class="delete pull-right btn btn-sm btn-primary trigger">Delete</button>
                 <button type="button" class="edit pull-right btn btn-sm btn-primary trigger" aria-expanded="false">Change &rarr;</button>
                 <div class="expandable">
-                    <h7 tabindex="-1">Change permissions</h7>
                     [% PROCESS _permissions_for_group %]
                     <button type="button" class="ok btn btn-sm btn-primary">Ok</button>
                 </div>
@@ -83,7 +82,7 @@
             </label>
             <select id="select-permission-group">
             [% FOREACH group IN groups.all %]
-                <option class="permission-group-[% group.id %]" value="[% group.id %]">[% group.name %]</option>
+                <option value="[% group.id %]">[% group.name %]</option>
             [% END %]
             </select>
 
@@ -111,7 +110,6 @@
 
 <section id="permissions" class="[% FOREACH p IN existing_perms; 'permission-group-' _ p _ ' '; END %]">
     <h4>Permissions [% whats_this('modalhelp_groups') %]</h4>
-    [% IF column.id %]
 
         [% IF NOT column.permissions.size %]
             <p>Access must be granted to this field before anyone (including you) can view and edit data in it.</p>
@@ -122,15 +120,6 @@
             [% END %]
         [% END %]
 
-        [% MACRO group_list(groups) BLOCK %]
-            <ul>
-                [% FOREACH group IN groups %]
-                <li>[% group %]</li>
-                [% END %]
-            </ul>
-        [% END %]
-
-        [% IF column.permissions.size %]
         <div id="current-permissions" aria-live="polite">
             <ul>
                 [% FOREACH group IN groups.all %]
@@ -165,7 +154,7 @@
                     <button type="button" class="edit pull-right btn btn-sm btn-primary trigger" aria-expanded="false">Change &rarr;</button>
                     <div class="expandable">
                         <h7 tabindex="-1">Change permissions</h7>
-                        [% PROCESS _permissions_for_group group = group_id %]
+                        [% PROCESS _permissions_for_group %]
                         <button type="button" class="ok btn btn-sm btn-primary">Ok</button>
                     </div>
                 </li>
@@ -173,21 +162,9 @@
             </ul>
         </div>
 
-        [% END %]
-    [% ELSE # no column %]
-        [% # TODO: symptom of system. Fix. %]
-        <p>Please save the field before adding permissions</p>
-    [% END %]
 
     [% IF groups.all.size %]
         <button id="configure-permissions" type="button" class="btn btn-default">Add permissions</button>
-        <style>
-        [% FOREACH group IN groups.all %]
-            #permissions.permission-group-[% group.id %] option.permission-group-[% group.id %] {
-                display: none;
-            }
-        [% END %]
-        </style>
         <section id="permission-configuration" hidden>
             [% PROCESS _permission_configuration %]
         </section>

--- a/views/snippets/layout_permissions.tt
+++ b/views/snippets/layout_permissions.tt
@@ -63,7 +63,7 @@
                 <button type="button" class="delete pull-right btn btn-sm btn-primary trigger">Delete</button>
                 <button type="button" class="edit pull-right btn btn-sm btn-primary trigger" aria-expanded="false">Change &rarr;</button>
                 <div class="expandable">
-                    [% PROCESS _permissions_for_group %]
+                    [% PROCESS _permissions_for_group group = undef %]
                     <button type="button" class="ok btn btn-sm btn-primary">Ok</button>
                 </div>
             </li>
@@ -88,14 +88,12 @@
 
             <p>Members of this group will have the following access rights:</p>
 
-            [% PROCESS _permissions_for_group %]
+            [% PROCESS _permissions_for_group group = undef %]
 
             <button id="add-permission-rule" type="button" class="btn btn-default add-permission">Add rule</button>
             <button id="cancel-permission-rule" type="button" class="btn btn-default cancel-permission">Cancel</button>
         </section>
     </li>
-
-        </script>
 
     [% ELSE %]
         <p>No groups have been created yet. <a href="/group">Create a group.</a></p>
@@ -154,7 +152,7 @@
                     <button type="button" class="edit pull-right btn btn-sm btn-primary trigger" aria-expanded="false">Change &rarr;</button>
                     <div class="expandable">
                         <h7 tabindex="-1">Change permissions</h7>
-                        [% PROCESS _permissions_for_group %]
+                        [% PROCESS _permissions_for_group group = group_id %]
                         <button type="button" class="ok btn btn-sm btn-primary">Ok</button>
                     </div>
                 </li>

--- a/views/snippets/layout_permissions.tt
+++ b/views/snippets/layout_permissions.tt
@@ -7,51 +7,40 @@
     END;
 %]
     <li data-group-id="[% perm %]">
-        <h5>
-            [% group.name %]
-            <button type="button" class="btn btn-sm btn-default" data-perm-id="[% perm %]">Delete rule</button>
-        </h5>
+        <section class="permission-rule">
+            <h5 class="clearfix">
+                Group: [% group.name %]
+                <button type="button" class="btn btn-sm btn-default pull-right" data-perm-id="[% perm %]">Delete rule</button>
+            </h5>
 
-        <section>
-            <h6>Access</h6>
-            <div class="row">
-                <div class="form-group col-md-3">
-                    <input type="checkbox" id="can_read" name="read" [% column.group_has(perm, 'read') && 'checked' %]>
-                    <label for="can_read">Read</label>
-                </div>
+            <p>Members of this group will have the following access rights:</p>
 
-                 <div class="form-group col-md-3">
-                    <input type="checkbox" id="[% perm %]-can_write_new" name="write_new" [% column.group_has(perm, 'write_new') && 'checked' %]>
-                    <label for="[% perm %]-can_write_new">Write values to new records</label>
-                </div>
-
-                <div class="form-group col-md-3">
-                    <input type="checkbox" id="[% perm %]-can_edit_existing" name="write_existing" [% column.group_has(perm, 'write_existing') && 'checked' %]>
-                    <label for="[% perm %]-can_edit_existing">Edit existing values</label>
-                </div>
+            <div class="form-group">
+                <input type="checkbox" id="can_read" name="read" [% column.group_has(perm, 'read') && 'checked' %]>
+                <label for="can_read">Users have read access to this field</label>
             </div>
-        </section>
 
-        <section>
-            <h6>Approval</h6>
-            <div class="row">
-                <div class="form-group col-md-6">
-                    <input type="checkbox" id="[% perm %]-can_create_without_approval" name="write_new_no_approval" [% column.group_has(perm, 'write_new_no_approval') && 'checked' %]>
-                    <label for="[% perm %]-can_create_without_approval">No approval required for new records</label>
-                </div>
-                <div class="form-group col-md-6">
-                    <input type="checkbox" id="[% perm %]-can_edit_without_approval" name="write_existing_no_approval" [% column.group_has(perm, 'write_existing_no_approval') && 'checked' %]>
-                    <label for="[% perm %]-can_edit_without_approval">No approval required for editing values</label>
-                </div>
-                <div class="form-group col-md-6">
+             <div class="form-group permission write-new">
+                <input type="checkbox" id="[% perm %]-can_write_new" name="write_new" [% column.group_has(perm, 'write_new') && 'checked' %]>
+                <label for="[% perm %]-can_write_new">Values can be written to new records</label>
+
+                <div class="form-group permission">
                     <input type="checkbox" id="[% perm %]-can_approve_new" name="approve_new" [% column.group_has(perm, 'approve_new') && 'checked' %]>
-                    <label for="[% perm %]-can_approve_new">Approve new values</label>
-                </div>
-                <div class="form-group col-md-6">
-                    <input type="checkbox" id="[% perm %]-can_approve_edits" name="approve_existing" [% column.group_has(perm, 'approve_existing') && 'checked' %]>
-                    <label for="[% perm %]-can_approve_edits">Approve edits</label>
+                    <label for="[% perm %]-can_approve_new">Values for new records need approval</label>
                 </div>
             </div>
+
+            <div class="form-group permission modify-existing">
+                <input type="checkbox" id="[% perm %]-can_edit_existing" name="write_existing" [% column.group_has(perm, 'write_existing') && 'checked' %]>
+                <label for="[% perm %]-can_edit_existing">Existing values can be modified</label>
+
+                <div class="form-group permission">
+                    <input type="checkbox" id="[% perm %]-can_approve_edits" name="approve_existing" [% column.group_has(perm, 'approve_existing') && 'checked' %]>
+                    <label for="[% perm %]-can_approve_edits">Modifications need approval</label>
+                </div>
+            </div>
+
+                
         </section>
     </li>
 [% END %]
@@ -80,7 +69,7 @@
 
 [% BLOCK layout_permissions %]
 <section id="permissions">
-    <h3>Permissions [% whats_this('modalhelp_groups') %]</h3>
+    <h4>Permissions [% whats_this('modalhelp_groups') %]</h4>
     [% IF column.id %]
 
         [% IF NOT column.permissions.size %]

--- a/views/snippets/util.tt
+++ b/views/snippets/util.tt
@@ -1,5 +1,5 @@
 [% MACRO whats_this(ref, text) BLOCK %]
-    <button class="btn btn-xs btn-default" aria-haspopup="true"
+    <button type="button" class="btn btn-xs btn-default" aria-haspopup="true"
         data-toggle="modal" data-target="#[% ref %]">[% text || 'what&apos;s this?' %]
         <span aria-hidden="true" class="glyphicon glyphicon-info-sign"></span>
     </button>

--- a/views/snippets/util.tt
+++ b/views/snippets/util.tt
@@ -1,0 +1,6 @@
+[% MACRO whats_this(ref, text) BLOCK %]
+    <button class="btn btn-xs btn-default" aria-haspopup="true"
+        data-toggle="modal" data-target="#[% ref %]">[% text || 'what&apos;s this?' %]
+        <span aria-hidden="true" class="glyphicon glyphicon-info-sign"></span>
+    </button>
+[% END %]


### PR DESCRIPTION
This PR intends to increase the usability and accessibility of permission management.

It's not ready to go - it needs to have the Perl side of things checked. I'm currently not sure if the `GADS::Column::set_permissions` code is proper. Would like to discuss.

There are also further layout considerations, but I don't want this PR to drag on, and would rather sort those as part of PR #17. 

In particular, consider 
https://github.com/ctrlo/GADS/compare/menu...jkva:manage-fields-accessibility?expand=1#diff-9d7d58d369534d9abedb301a797a7298R936