### PR TITLE
Brass issue #427 - Add current page as attribute to body element

### DIFF
--- a/views/layouts/main.tt
+++ b/views/layouts/main.tt
@@ -77,7 +77,7 @@
         <![endif]-->
     </head>
 
-    <body class="page [% page %]">
+    <body class="page [% page %]" data-page="[% page %]">
         <header role="banner" class="container">
         [% IF header AND NOT page_as_mech %]
             <p class="text-center">[% header %]</p>


### PR DESCRIPTION
It seems that the `data-page` attribute got removed from the `<body>` element during a merge. This caused the JS to throw. 

Likely this also sorts Brass Issue 428 - Unable to add new permissions.