### PR TITLE
Early rewrite of custom bootstrap selector dropdown

### DIFF
--- a/views/edit.tt
+++ b/views/edit.tt
@@ -86,7 +86,7 @@
                 $(this).find('.modal-body').load(loadurl);
             });
 
-            $(document).on("mousedown", ".moreinfo", function(e) {
+            $(document).on("click", ".read-more", function(e) {
                 var record_id = $(e.target).data('record-id');
                 var m = $("#readmore_modal");
                 m.find('.modal-body').text('Loading...');
@@ -412,7 +412,8 @@
                     > <span [% label_style %]>[% label %]</span>
                 </label>
             </div>
-        [% ELSE %]
+        [% ELSIF dispcol.type != "curval" %]
+            [% #FIXME hack, since curval is a widget that cannot have a label %]
             <label for="[% dispcol.id %]" [% label_style %]>
                 [% label %][% IF oldvalue %] (current value &quot;[% oldvalue %]&quot;)[% END %]
             </label>
@@ -474,44 +475,7 @@
                             name="[% field %]_typeahead" value="[% IF record %][% editvalue.html %][% END %]" [% readonly %] >
                         [% typeaheads.push({id = dispcol.id, field = field }) %]
                     [% ELSE %]
-                        [% IF dispcol.multivalue %]
-                            [%# Ensure a value gets sent back to show this field was shown if nothing selected %]
-                            <input type="hidden" name="[% field %]">
-                        [% END %]
-                        <select class="form-control [% IF dispcol.has_subvalues %]selectpicker [% END %]"
-                            name="[% field %]" id="[% dispcol.id %]" [% IF readonly %]disabled[% END %]
-                            [% IF dispcol.has_subvalues %]
-                                data-multiple-separator="; " data-window-padding="70"
-                                [% IF dispcol.multivalue %]multiple[% END %]
-                            [% END %]>
-                            [% IF !dispcol.multivalue %]
-                                [% IF dispcol.optional OR editvalue.deleted OR (record.current_id AND NOT editvalue.id) OR NOT record.current_id %]
-                                    <option></option>
-                                [% END %]
-                            [% END %]
-                            [% IF page == "bulk" %]
-                                [% enumvals = dispcol.all_values %]
-                            [% ELSE %]
-                                [% enumvals = dispcol.filtered_values %]
-                            [% END %]
-                            [% FOREACH enumval IN enumvals %]
-                                [% UNLESS enumval.deleted %]
-                                    <option value="[% enumval.id %]" [% IF editvalue.id_hash.${enumval.id} %]selected[% END %]
-                                        [% IF dispcol.has_subvalues %]
-                                            title="[% enumval.mainvalue | html_entity %]" [%# only show main title in selection %]
-                                            [%# custom content for each option in order to show tooltip text %]
-                                            data-content="<span title='[% enumval.value | html_entity %]'>
-                                                [% enumval.mainvalue | html_entity %]
-                                                <small class='text-muted'>[% enumval.subvalue | html_entity %]</small>
-                                                <span class='moreinfo' data-record-id='[% enumval.id %]'>Read more...</span>
-                                            </span>"
-                                        [% END %]
-                                    >
-                                    [% enumval.value | html_entity %]
-                                    </option>
-                                [% END %]
-                            [% END %]
-                        </select>
+                        [% PROCESS curval_multivalue_field col = dispcol %]
                     [% END %]
                 [% ELSIF dispcol.type == "tree" %]
                     <input type="hidden" name="[% field %]" id="treeval_id[% dispcol.id %]" value="[% editvalue.id %]">
@@ -670,3 +634,36 @@
         </div>
     [% END %]
 [% END %]
+
+[% BLOCK curval_multivalue_field %]
+    [% #FIXME How can we deal with the rigid label+field template structure? %]
+
+    [% IF page == "bulk" %]
+        [% enumvals = dispcol.all_values %]
+    [% ELSE %]
+        [% enumvals = dispcol.filtered_values %]
+    [% END %]
+
+    [% IF dispcol.multivalue %] 
+        [%# Ensure a value gets sent back to show this field was shown if nothing selected %]
+        <input type="hidden" name="[% field %]">
+    [% END %]
+
+    <fieldset>
+        <legend>[% label %]</legend>
+        <ul class="curval-multiselect">
+        [% FOREACH enumval IN enumvals %]
+            <li>
+                [% checked = editvalue.id_hash.${enumval.id} %] 
+                [% enumval_id = col.id _ '_' _ enumval.id %]
+                <div class="form-group">
+                    <input type="checkbox" name="[% enumval_id %]" value="[% enumval.id %]" [% checked && 'checked' %] id="[% enumval_id %]">
+                    <label for="[% enumval_id %]">[% enumval.value | html_entity %]</label>
+                </div>
+                <button type="button" class="read-more" data-record-id="[% enumval.id %]">Show full details</button>
+            </li>
+        [% END %]
+        </ul>
+    </fieldset>
+[% END %]
+


### PR DESCRIPTION
@abeverley things this still needs:

* proper responsive styling (mainly for scrolling)
* the field rendering logic needs to have a way to either render an associative label (as it does by default) or render something else
* connected backend handling

Ideally I'd like to clean this template up into a block for each different field type, so we have more control over rendering logic and such. It's hard to debug otherwise. 