### PR TITLE
Only show field save button when relevant

### DIFF
--- a/views/layout.tt
+++ b/views/layout.tt
@@ -650,6 +650,7 @@
         %]
     </section>
 
+[% IF column.defined %]
     <div class="row controls">
         <div class="col-md-12">
             <button type="submit" id="submit_save" name="submit" value="submit" class="btn btn-primary">[% IF column.id %]Save[% ELSE %]Save[% END %]</button>
@@ -659,6 +660,7 @@
         [% END %]
         </div>
     </div>
+[% END %]
 </form>
 
 [%


### PR DESCRIPTION
This should sort Brass issue #463 - duplicate save buttons in layout.