### PR TITLE
Reintroduce layout tabpanel CSS

### DIFF
--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1536,6 +1536,63 @@ small.search_term {
   background-color: rgba(137, 30, 136, 0.3); }
 
 /* manage-fields */
+.tab-interface [role="tablist"] {
+  list-style-type: none;
+  margin: 2.5em 0;
+  margin-bottom: .9em;
+  padding: 0; }
+
+.tab-interface [role="tablist"] li {
+  margin: 0;
+  display: inline-block; }
+
+.tab-interface [role="tablist"] li:not(:first-child) {
+  margin-left: 1em; }
+
+.tab-interface [role="tab"] {
+  padding: 1em;
+  border: 2px solid #1460aa;
+  text-decoration: none;
+  position: relative;
+  top: 2px;
+  border-bottom: 0; }
+
+.tab-interface [role="tab"][aria-selected="false"] {
+  border: 0; }
+
+.tab-interface [role="tab"][aria-selected="true"] {
+  background-color: #fff;
+  font-weight: bold; }
+
+.tab-interface [role="tab"]:focus,
+.tab-interface [role="tab"]:hover {
+  text-decoration: solid underline black;
+  outline: 0; }
+
+.tab-interface [role="tabpanel"] {
+  border: 2px solid #1460aa;
+  padding: 1em;
+  display: none; }
+
+.tab-interface [role="tabpanel"].active {
+  display: block; }
+
+.tab-interface [role="tabpanel"] h3:first-child {
+  margin: .5em 0 1em 0; }
+
+@media screen and (max-width: 41em) {
+  .tab-interface [role="tablist"] {
+    margin: 0; }
+
+  .tab-interface [role="tablist"] li,
+  .tab-interface [role="tab"] {
+    display: block; }
+
+  .tab-interface [role="tablist"] li:not(:first-child) {
+    margin: 0; }
+
+  .tab-interface [role="tab"] {
+    border: 2px solid; } }
 #manage-fields {
   border-bottom: 1px solid #bbb;
   padding-bottom: .5em; }
@@ -1589,7 +1646,6 @@ small.search_term {
 #manage-fields #advanced-field-settings h3,
 #manage-fields h4 {
   display: inline-block;
-  border-bottom: 1px solid #bbb;
   padding-bottom: .5em; }
 
 #manage-fields .permission.write-new .permission,

--- a/sass/_permissions.scss
+++ b/sass/_permissions.scss
@@ -1,5 +1,78 @@
 /* manage-fields */
 
+.tab-interface [role="tablist"] {
+    list-style-type: none;
+    margin: 2.5em 0;
+    margin-bottom: .9em;
+    padding: 0;
+}
+
+.tab-interface [role="tablist"] li {
+    margin: 0;
+    display: inline-block;
+}
+
+.tab-interface [role="tablist"] li:not(:first-child) {
+    margin-left: 1em;
+}
+
+.tab-interface [role="tab"] {
+    padding: 1em;
+    border: 2px solid $primary-navy;
+    text-decoration: none;
+    position: relative;
+    top: 2px;
+    border-bottom: 0;
+}
+.tab-interface [role="tab"][aria-selected="false"] {
+    border: 0;
+}
+
+.tab-interface [role="tab"][aria-selected="true"] {
+    background-color: #fff;
+    font-weight: bold;
+}
+
+.tab-interface [role="tab"]:focus,
+.tab-interface [role="tab"]:hover {
+    text-decoration: solid underline black;
+    outline: 0;
+}
+
+.tab-interface [role="tabpanel"] {
+    border: 2px solid $primary-navy;
+    padding: 1em;
+    display: none;
+}
+
+.tab-interface [role="tabpanel"].active {
+    display: block;
+}
+
+.tab-interface [role="tabpanel"] h3:first-child {
+    margin: .5em 0 1em 0;
+}
+
+@media screen and (max-width: 41em) {
+    .tab-interface [role="tablist"] {
+        margin: 0;
+    }
+
+    .tab-interface [role="tablist"] li,
+    .tab-interface [role="tab"] {
+        display: block;
+    }
+
+    .tab-interface [role="tablist"] li:not(:first-child) {
+        margin: 0;
+    }
+
+    .tab-interface [role="tab"] {
+        border: 2px solid;
+    }
+
+}
+
 #manage-fields {
     border-bottom: 1px solid #bbb;
     padding-bottom: .5em;
@@ -35,7 +108,6 @@
 #manage-fields #advanced-field-settings h3,
 #manage-fields h4 {
     display: inline-block;
-    border-bottom: 1px solid #bbb;
     padding-bottom: .5em;
 }
 


### PR DESCRIPTION
This brings back the tabpanel layout as removed by a recent merger. It's also been moved to its proper sass import file.