### PR TITLE
Allow select widgets to break out of its panel

### DIFF
--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -1171,8 +1171,7 @@ a.list-group-item-danger.active, a.list-group-item-danger.active:hover, a.list-g
   margin-bottom: 21px; }
 
 .panel-group .panel {
-  border-radius: 0px;
-  overflow: hidden; }
+  border-radius: 0px; }
 
 .panel-primary {
   border-color: #1460aa; }

--- a/sass/ctrlo-bootstrap.scss
+++ b/sass/ctrlo-bootstrap.scss
@@ -846,7 +846,6 @@ a.list-group-item-danger.active,a.list-group-item-danger.active:hover,a.list-gro
 }
 .panel-group .panel {
         border-radius:0px;
-        overflow:hidden;
 }
 .panel-primary {
         border-color:$primary-navy;


### PR DESCRIPTION
The solution as included in the PR is quiet simple. It allow html elements to go outside the boundaries of a panel. But since a style to actually hide overflowing elements was in place, this change might break other things. It might have been there for a reason I don't know of. Maybe you have any idea? If not, just keep in mind that if you see something outside a panel that should've been cut off/hidden, this might be the reason :) 