### PR TITLE
Fix weird reopening of single select widget in firefox

### DIFF
--- a/public/js/linkspace.js
+++ b/public/js/linkspace.js
@@ -326,6 +326,7 @@ var SelectWidget = function (multi) {
                 // its label. When the input is hidden on the click event of the label
                 // the input isn't actually being selected.
                 setTimeout(function() {
+                    document.activeElement.blur();
                     $target.attr('hidden', '');
                     $search.val('');
                     $answers.removeAttr('hidden');


### PR DESCRIPTION
It seems the focus was still on the radio button after closing,
causing a click event to be triggered when trying to open up
another widget.