### PR TITLE
Further DBIC simplification

### DIFF
--- a/lib/GADS/Instances.pm
+++ b/lib/GADS/Instances.pm
@@ -199,9 +199,7 @@ sub layout_by_shortname
     })->next;
     if (!$layout && $shortname =~ /^table([0-9]+)$/)
     {
-        $layout = $self->schema->resultset('Instance')->search({
-            id => $1,
-        })->next;
+        $layout = $self->schema->resultset('Instance')->find($1);
     }
     if (!$layout)
     {

--- a/lib/GADS/Layout.pm
+++ b/lib/GADS/Layout.pm
@@ -628,10 +628,13 @@ has cols_db => (
 
 sub _build_cols_db
 {   my $self = shift;
+    my $schema = $self->schema;
     # Must search by instance_ids to limit between sites
-    my @instance_ids = map { $_->id } $self->schema->resultset('Instance')->all;
-    my $cols_rs = $self->schema->resultset('Layout')->search({
-        'me.instance_id' => \@instance_ids,
+    my $instance_id_sql = $schema->resultset('Instance')
+        ->get_column('id')
+        ->as_query;
+    my $cols_rs = $schema->resultset('Layout')->search({
+        'me.instance_id' => { -in => $instance_id_sql },
     },{
         order_by => ['me.position', 'enumvals.id'],
         join     => 'enumvals',

--- a/lib/GADS/Records.pm
+++ b/lib/GADS/Records.pm
@@ -149,9 +149,7 @@ sub _build__view_limit_extra
         if $default && !$self->layout->user_can("view_limit_extra");
     if ($extra)
     {
-        my $view_limit = $self->schema->resultset('View')->search({
-            'me.id' => $extra,
-        })->next;
+        my $view_limit = $self->schema->resultset('View')->find($extra);
         return GADS::View->new(
             id          => $view_limit->id,
             schema      => $self->schema,


### PR DESCRIPTION
Using find() instead of search()->next() in this well-tested code seems
like a worthwhile low risk improvement.