### PR TITLE
no underline in buttons with href

### DIFF
--- a/public/css/ctrlo-bootstrap.css
+++ b/public/css/ctrlo-bootstrap.css
@@ -843,6 +843,7 @@ select.input-lg {
   font-size: 15px;
   border-radius: 0px;
   cursor: auto;
+  text-decoration: none;
 }
 
 .btn-default {


### PR DESCRIPTION
Buttons without href are triggered by Javascript: their contained text is not underlined.  There is no reason to have a different visual effect on buttons which are link based.