### PR TITLE
WebDriver tests for all records shown

### DIFF
--- a/webdriver/t/create_view.t
+++ b/webdriver/t/create_view.t
@@ -152,6 +152,20 @@ $gads->assert_success_present('The second record was added successfully');
 $gads->assert_error_absent(
     'No error message is visible after adding the second record' );
 $gads->assert_on_see_records_page;
+$gads->assert_records_shown(
+    'The see records page shows the added records',
+    [
+        {
+            $text_field_name => 'One hundred and twenty three',
+            $int_field_name => 123,
+        },
+        {
+            $text_field_name => 'Twenty four',
+            $int_field_name => 24,
+        },
+    ],
+);
+
 
 $gads->navigate_ok(
     'Navigate to the add a view page',


### PR DESCRIPTION
Before creating a view, test all records are shown.  This means we need
to look for a different attribute (views use "aria-label", all records
use "data-thlabel") and filter out the default fields.

I could have filtered out those fields using Test::Deep, but in keeping
with the Test2 approach used in Test::GADSDriver, I decided not to.
However, I couldn't figure out how to check a subset of fields easily
using Test2 so I've commented on that as something to do in future.