### PR TITLE
Remove an unused dependency

### DIFF
--- a/lib/GADS/Column.pm
+++ b/lib/GADS/Column.pm
@@ -27,7 +27,6 @@ use GADS::Filter;
 use GADS::Groups;
 use GADS::Type::Permission;
 use GADS::View;
-use MIME::Base64 'encode_base64';
 
 use Moo;
 use MooX::Types::MooseLike::Base qw/:all/;


### PR DESCRIPTION
The only encode_base64() call in this module was removed in 9f92b02a69a.