### PR TITLE
Run the login.t Webdriver test in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,39 @@
+dist: bionic
 language: perl
-perl:
-    - "5.30"
-    - "5.28"
-addons:
-    apt:
-        packages:
-            # Required by Inline::Lua
+jobs:
+  include:
+    - name: 5.28 unit tests
+      perl: "5.28"
+    - name: 5.30 unit tests
+      perl: "5.30"
+    - name: 5.30 Webdriver tests
+      perl: "5.30"
+      env: GADS_USERNAME=test@example.com GADS_PASSWORD=xyz123
+      before_script: ./bin/setup_for_webdriver
+      install:
+        - cd $BUILD_DIR/webdriver
+        - cpan-install --deps
+        - cd $BUILD_DIR
+        - cpan-install --deps
+      services:
+        - postgresql
+      script:
+        # TODO: when webdriver/t/create_view.t passes - prove -lmrsv webdriver/t
+        - prove -lmv webdriver/t/login.t
+      addons:
+        apt:
+          packages:
+            # Copied from the default
             - liblua5.3-dev
+            # Extra Webdriver requirements
+            - firefox
+            - firefox-geckodriver
+addons:
+  apt:
+    packages:
+      # Required by Inline::Lua
+      - liblua5.3-dev
 before_install:
-    # See https://github.com/travis-perl/helpers/blob/master/README.md
-    - eval $(curl https://travis-perl.github.io/init) --auto
-script:
-    - prove -lrs -j$(test-jobs) $(test-files)
+  # See https://github.com/travis-perl/helpers/blob/master/README.md
+  - eval $(curl https://travis-perl.github.io/init) --auto
+script: prove -lrs -j$(test-jobs) $(test-files)

--- a/bin/setup_for_webdriver
+++ b/bin/setup_for_webdriver
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -eu
+
+# Read config.yml from this directory
+export DANCER_CONFDIR=webdriver
+
+: ${GADS_HOSTNAME:=localhost}
+: ${PSQL_USER:=linkspace}
+: ${PSQL_PASSWORD:=linkspace}
+: ${PSQL_DATABASE:=linkspace}
+
+echo "
+    CREATE USER ${PSQL_USER} WITH PASSWORD '${PSQL_USER}';
+    CREATE DATABASE ${PSQL_DATABASE} OWNER ${PSQL_USER};
+" | psql -U postgres
+echo "
+    CREATE EXTENSION IF NOT EXISTS citext WITH SCHEMA public;
+" | psql -U postgres ${PSQL_DATABASE}
+
+# Deploy the database
+perl bin/seed-database.pl \
+    --initial_username "${GADS_USERNAME}" \
+    --instance_name WebDriverTestSheet \
+    --site "${GADS_HOSTNAME}"
+
+perl -Ilib -MDancer2 -MDancer2::Plugin::Auth::Extensible -wE \
+    "user_password username => '${GADS_USERNAME}', new_password => '${GADS_PASSWORD}'"
+
+echo "
+    UPDATE public.site SET host = '${GADS_HOSTNAME}';
+    UPDATE public.user SET account_request = 0, pwchanged = NOW();
+" | psql -U postgres ${PSQL_DATABASE}
+
+# Start Linkspace
+perl bin/app.pl &
+
+# Start geckodriver (TODO: Read up on Travis background jobs)
+MOZ_HEADLESS=1 geckodriver --log warn &

--- a/webdriver/Makefile.PL
+++ b/webdriver/Makefile.PL
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    PREREQ_PM => {
+        'List::MoreUtils'       => 0,
+        'Test2::API'            => 0,
+        'Test2::Tools::Compare' => 0,
+        'WebDriver::Tiny'       => 0,
+    },
+);

--- a/webdriver/Makefile.PL
+++ b/webdriver/Makefile.PL
@@ -5,6 +5,8 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     PREREQ_PM => {
         'List::MoreUtils'       => 0,
+        'Moo'                   => 0,
+        'Test::More'            => 0,
         'Test2::API'            => 0,
         'Test2::Tools::Compare' => 0,
         'WebDriver::Tiny'       => 0,

--- a/webdriver/README.md
+++ b/webdriver/README.md
@@ -8,7 +8,7 @@ WebDriver integration tests for the entire application.
 
 ```
 # Install the required CPAN modules
-cpan List::MoreUtils Test2::API Test2::Tools::Compare WebDriver::Tiny
+cd webdriver; cpan .
 
 # Run geckodriver (or similar for your browser, perhaps chromedriver)
 geckodriver

--- a/webdriver/config.yml
+++ b/webdriver/config.yml
@@ -1,0 +1,52 @@
+# Webdriver integration testing configuration
+
+appname: "Linkspace Integration Tests"
+layout: "main"
+charset: "UTF-8"
+template: "template_toolkit"
+logger: LogReport
+session: "Simple"
+gads:
+    header: "Example Application"
+    hostlocal: 1
+    dateformat: "yyyy-MM-dd"
+    email_from: "Linkspace Integration Tests <nobody@example.com>"
+    aup: 0
+    login_instance: 1
+    default_instance: 1
+    url: "http://invalidhost.example.com/"
+    user_status: 0
+
+plugins:
+    LogReport:
+        session_messages: [ NOTICE, MISTAKE, ERROR, FAULT, ALERT, FAILURE, PANIC ]
+    DBIC:
+        default:
+            dsn: dbi:Pg:database=linkspace
+            schema_class: GADS::Schema
+            user: linkspace
+            password: linkspace
+            options:
+                RaiseError: 1
+                PrintError: 1
+                quote_names: 1
+    Auth::Extensible:
+        no_default_pages: 1
+        no_login_handler: 1
+        record_lastlogin: 1
+        realms:
+            dbic:
+                provider: DBIC
+                user_as_object: 1
+                users_resultset: User
+                roles_resultset: Permission
+                user_roles_resultset: UserPermission
+                roles_role_column: name
+                roles_key: permission
+                password_expiry_days: 5
+                users_pwchanged_column: pwchanged
+                users_pwresetcode_column: resetpw
+                encryption_algorithm: SHA-512
+                user_valid_conditions:
+                    deleted: ~
+                    account_request: 0


### PR DESCRIPTION
These changes introduce a new Travis job that runs the `login.t` test script against a local deployment of the Web application and a local Postgres database.

Currently, `create_view.t` fails one test in Travis, but we can fix that later and easily enable it as described in the _TODO_ in `.travis.yml`.