### PR TITLE
Update the CPAN dependencies

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -59,7 +59,7 @@ our %prereq_pm = (
     'Tie::Cache'                                => 0,
     'Tree::DAG_Node'                            => 0,
     'WWW::Form::UrlEncoded::XS'                 => 0,
-    'WWW::Mechanize::PhantomJS'                 => 0,
+    'WWW::Mechanize::Chrome'                    => 0,
     'YAML'                                      => 0,
 );
 


### PR DESCRIPTION
Commit 6f8dd03bb02ef replaced PhantomJS with Chrome, causing test to
fail in a development environment with the old modules installed.

The failing tests, t/001_base.t and t/002_index_route.t, only run in the
presence of a config.yml file, so our current CI setup did not notice
this problem.