### PR TITLE
Minor logging improvements

### DIFF
--- a/config.yml-example
+++ b/config.yml-example
@@ -1,3 +1,6 @@
+# Linkspace configuration.  Also see the files in the "environments"
+# directory that extend this configuration.
+#
 # Your application's name
 appname: "Linkspace"
 

--- a/environments/development.yml
+++ b/environments/development.yml
@@ -1,10 +1,9 @@
 # configuration file for development environment
+#
+# To override or extend these values, create a
+# environments/development_local.yml file:
+# https://metacpan.org/pod/distribution/Dancer2/lib/Dancer2/Config.pod#MANIPULATING-SETTINGS-VIA-CONFIGURATION-FILES
 
-# the logger engine to use
-# console: log messages to STDOUT (your console where you started the
-#          application server)
-# file:    log message to a file in log/
-#logger: "console"
 
 # the log level for this environment
 # core is the lowest, it shows Dancer2's core log messages as well as yours
@@ -26,5 +25,7 @@ engines:
       app_name: GADS
       dispatchers:
         default:
-          type: PERL
+          type: FILE
           mode: DEBUG
+          format: LONG
+          to: /dev/stdout

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -31,7 +31,7 @@ engines:
     LogReport:
       app_name: GADS
       dispatchers:
-        syslog:
+        default:
           type: SYSLOG
           identity: GADS
           facility: local0

--- a/public/dispatch.fcgi
+++ b/public/dispatch.fcgi
@@ -10,6 +10,12 @@ use Plack::Handler::FCGI;
 set apphandler => 'PSGI';
 set environment => 'production';
 
+# Set the warning signal handler before loading GADS (via app.psgi) to
+# redirect any warnings to Log::Report during compilation, as well as
+# while the application runs.  However, there's a risk of trying to call
+# GADS::warning before it exists.
+$SIG{__WARN__} = sub { GADS::warning(@_) };
+
 my $psgi = path($RealBin, '..', 'bin', 'app.psgi');
 my $app = do($psgi);
 die "Unable to read startup script: $@" if $@;


### PR DESCRIPTION
Redirect warnings to Log::Report.

In production, only use Log::Report::Dispatcher::Syslog, by making it the default logger.  In development, only use Log::Report::Dispatcher::File to log at debug level to STDOUT with a timestamp using the "LONG" format.

Developers can override or extend these settings by creating their own `environments/development_local.yml`.