### PR TITLE
Give each page a unique indentifier name

### DIFF
--- a/lib/GADS.pm
+++ b/lib/GADS.pm
@@ -1006,7 +1006,7 @@ any ['get', 'post'] => '/table/:id' => require_role superadmin => sub {
     my $table_id   = $id ? $layout_edit->instance_id : 0;
 
     template 'table' => {
-        page        => $id ? 'table' : 'table/0',
+        page        => $id ? 'this_table' : 'table/0',
         layout_edit => $layout_edit,
         groups      => GADS::Groups->new(schema => schema)->all,
         breadcrumbs => [Crumb( '/table' => 'tables' ) => Crumb( "/table/$table_id" => $table_name )],

--- a/webdriver/t/lib/Test/GADSDriver.pm
+++ b/webdriver/t/lib/Test/GADSDriver.pm
@@ -498,8 +498,8 @@ sub assert_on_manage_tables_page {
 
     $self->_assert_on_page(
         $name,
-        { selector => 'h2', text => 'Manage tables' },
         'body.table',
+        { selector => 'h2', text => 'Manage tables' },
     );
 
     $test->release;
@@ -519,8 +519,8 @@ sub assert_on_manage_this_table_page {
 
     $self->_assert_on_page(
         $name,
-        { selector => 'h2', text => 'Manage this table' },
         'body.this_table',
+        { selector => 'h2', text => 'Manage this table' },
     );
 
     $test->release;
@@ -733,6 +733,9 @@ sub _assert_element {
     return $matching_el;
 }
 
+# Note: the first expression should always be a page ID, not a complex
+# hashref selector, as these don't check the full condition in a find()
+# call but instead use _check_element_against_expectation().
 sub _assert_on_page {
     my ( $self, $name, @expectation ) = @_;
     my $test = context();

--- a/webdriver/t/lib/Test/GADSDriver.pm
+++ b/webdriver/t/lib/Test/GADSDriver.pm
@@ -520,7 +520,7 @@ sub assert_on_manage_this_table_page {
     $self->_assert_on_page(
         $name,
         { selector => 'h2', text => 'Manage this table' },
-        'body.table',
+        'body.this_table',
     );
 
     $test->release;


### PR DESCRIPTION
This should finally stop the webdriver tests failing in CI.