### PR TITLE
Stop loading an unused module

### DIFF
--- a/bin/date-format.pl
+++ b/bin/date-format.pl
@@ -6,7 +6,6 @@ use lib "$FindBin::Bin/../lib";
 use Dancer2;
 use Dancer2::Plugin::DBIC;
 use Dancer2::Plugin::LogReport 'linkspace';
-use Path::Tiny;
 use GADS::DB;
 use GADS::Layout;
 use GADS::Column::Calc;
@@ -31,7 +30,6 @@ use Getopt::Long;
 use JSON qw();
 use Log::Report syntax => 'LONG';
 use String::CamelCase qw(camelize);
-use Path::Tiny;
 
 my ($new_format);
 

--- a/bin/import.pl
+++ b/bin/import.pl
@@ -48,7 +48,6 @@ use Getopt::Long;
 use JSON qw();
 use Log::Report syntax => 'LONG';
 use String::CamelCase qw(camelize);
-use Path::Tiny;
 
 my ($site_id, $purge, $add, $report_only, $merge, $update_cached, $force, $create_users, @ignore_fields);
 


### PR DESCRIPTION
Nothing in these scripts calls a method on Path::Tiny or its `path()` constructor.