### PR TITLE
Make a setup script more reusable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,10 +82,13 @@ jobs:
           chmod 600 ~/.pgpass
       - name: 'Start the application'
         env:
+          DANCER_CONFDIR: 'webdriver'
           PGDATABASE: 'postgres'
           PGHOST: 'localhost'
           PGUSER: 'postgres'
-        run: ./bin/setup_for_webdriver
+        run: |
+          ./bin/setup_database
+          perl bin/app.pl &
       - name: 'Run the Webdriver implementation'
         run: '${{ matrix.browser.command }}'
       - name: 'Run the Webdriver tests'

--- a/bin/setup_database
+++ b/bin/setup_database
@@ -2,16 +2,13 @@
 
 set -eu
 
-# Read config.yml from this directory
-export DANCER_CONFDIR=webdriver
-
 : ${GADS_HOSTNAME:=localhost}
 : ${PSQL_USER:=linkspace}
 : ${PSQL_PASSWORD:=linkspace}
 : ${PSQL_DATABASE:=linkspace}
 
 echo "
-    CREATE USER ${PSQL_USER} WITH PASSWORD '${PSQL_USER}';
+    CREATE USER ${PSQL_USER} WITH PASSWORD '${PSQL_PASSWORD}';
     CREATE DATABASE ${PSQL_DATABASE} OWNER ${PSQL_USER};
 " | psql -U postgres
 echo "
@@ -31,6 +28,3 @@ echo "
     UPDATE public.site SET host = '${GADS_HOSTNAME}';
     UPDATE public.user SET account_request = 0, pwchanged = NOW();
 " | psql -U postgres ${PSQL_DATABASE}
-
-# Start Linkspace
-perl bin/app.pl &


### PR DESCRIPTION
Separate out the "setup the database" and "run the application" parts.

While I'm here, fix setting the linkspace user's password.