### PR TITLE
GitHub Actions: update software versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,12 +4,12 @@ on: [ 'push', 'pull_request' ]
 jobs:
   unit_tests:
     name: 'Unit Tests'
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     timeout-minutes: 30
 
     steps:
       - name: 'Check out the GADS repository'
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
       - name: 'Install Non-CPAN dependencies'
         run: |
           sudo apt-get install cpanminus liblua5.3-dev
@@ -27,7 +27,7 @@ jobs:
 
   webdriver_tests:
     name: 'Webdriver Tests for ${{ matrix.browser.name }}'
-    runs-on: 'ubuntu-20.04'
+    runs-on: '${{ matrix.browser.os }}'
     timeout-minutes: 30
 
     strategy:
@@ -36,8 +36,10 @@ jobs:
         browser:
           - name: 'Chromium'
             command: 'chromedriver --port=4444 &'
+            os: 'ubuntu-22.04'
           - name: 'Firefox'
             command: 'MOZ_HEADLESS=1 geckodriver --log warn &'
+            os: 'ubuntu-20.04'
 
     services:
       postgres:
@@ -55,7 +57,7 @@ jobs:
 
     steps:
       - name: 'Check out the GADS code'
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
       - name: 'Install Non-CPAN dependencies'
         run: |
           sudo apt-get install cpanminus liblua5.3-dev


### PR DESCRIPTION
Ubuntu 22.04 does not support Firefox or Geckodriver easily, so stick with 20.04 for that.