### PR TITLE
Uiux

### DIFF
--- a/src/frontend/css/stylesheets/definitions/_variables.scss
+++ b/src/frontend/css/stylesheets/definitions/_variables.scss
@@ -106,6 +106,15 @@ $alert-border-width: 0;
 $alert-border-radius: 0;
 $alert-color-level: 0;
 
+$alert-bg-level:                    +10 !default;
+$alert-border-level:                +10 !default;
+$alert-color-level:                 6 !default;
+
+.alert {
+  color: #ffffff !important;
+}
+
+
 // Modals
 $modal-inner-padding: $padding-large-horizontal;
 $modal-header-padding-x: $padding-large-horizontal;

--- a/src/frontend/css/stylesheets/definitions/_variables.scss
+++ b/src/frontend/css/stylesheets/definitions/_variables.scss
@@ -8,6 +8,8 @@ $brand-danger:  #C14B3F;
 $brand-warning: #C57002;
 $brand-success: #719330;
 
+$warning: $brand-warning !default;
+
 $brand-secundary-hover: #294D94;
 
 $white: #FFF;
@@ -106,8 +108,8 @@ $alert-border-width: 0;
 $alert-border-radius: 0;
 $alert-color-level: 0;
 
-$alert-bg-level:                    +10 !default;
-$alert-border-level:                +10 !default;
+$alert-bg-level:                    +3 !default;
+$alert-border-level:                +4 !default;
 $alert-color-level:                 6 !default;
 
 .alert {


### PR DESCRIPTION
- Set default 'warning' colour to 'brand-warning'  so it no longer sets as 'yellow' 

- Set new  gradients for alert boxes to overwrite defaults

- set  .'alert'  text to white to overwrite default colours