### PR TITLE
Uiux

### DIFF
--- a/src/frontend/components/alert/_alert.scss
+++ b/src/frontend/components/alert/_alert.scss
@@ -3,6 +3,7 @@
   align-items: center;
   margin-bottom: $padding-large-vertical;
   padding: $padding-base-horizontal;
+  colour: #ffffff;
 
   &::before {
     @extend %icon-font;

--- a/src/frontend/components/alert/_alert.scss
+++ b/src/frontend/components/alert/_alert.scss
@@ -3,7 +3,7 @@
   align-items: center;
   margin-bottom: $padding-large-vertical;
   padding: $padding-base-horizontal;
-  colour: #ffffff;
+  color: #ffffff;
 
   &::before {
     @extend %icon-font;

--- a/src/frontend/components/alert/_alert.scss
+++ b/src/frontend/components/alert/_alert.scss
@@ -3,7 +3,7 @@
   align-items: center;
   margin-bottom: $padding-large-vertical;
   padding: $padding-base-horizontal;
-  color: #ffffff;
+  color: $white;
 
   &::before {
     @extend %icon-font;

--- a/src/frontend/components/dropdown/_dropdown-group.scss
+++ b/src/frontend/components/dropdown/_dropdown-group.scss
@@ -4,8 +4,8 @@
 
 .dropdown__group-title {
   padding: $padding-small-vertical $padding-base-horizontal 0;
-  color: $gray;
-  font-size: $font-size-sm;
+  color: $brand-primary;
+  @include font-style-h2;
 }
 
 .dropdown__list {

--- a/src/frontend/css/stylesheets/definitions/_variables.scss
+++ b/src/frontend/css/stylesheets/definitions/_variables.scss
@@ -112,11 +112,6 @@ $alert-bg-level:                    +3 !default;
 $alert-border-level:                +4 !default;
 $alert-color-level:                 6 !default;
 
-.alert {
-  color: #ffffff !important;
-}
-
-
 // Modals
 $modal-inner-padding: $padding-large-horizontal;
 $modal-header-padding-x: $padding-large-horizontal;

--- a/src/frontend/css/stylesheets/definitions/_variables.scss
+++ b/src/frontend/css/stylesheets/definitions/_variables.scss
@@ -107,8 +107,8 @@ $table-cell-padding: $padding-base-horizontal;
 $alert-border-width: 0;
 $alert-border-radius: 0;
 $alert-color-level: 0;
-$alert-bg-level:                    +3 !default;
-$alert-border-level:                +4 !default;
+$alert-bg-level: +3 !default;
+$alert-border-level: +4 !default;
 
 // Modals
 $modal-inner-padding: $padding-large-horizontal;

--- a/src/frontend/css/stylesheets/definitions/_variables.scss
+++ b/src/frontend/css/stylesheets/definitions/_variables.scss
@@ -107,10 +107,8 @@ $table-cell-padding: $padding-base-horizontal;
 $alert-border-width: 0;
 $alert-border-radius: 0;
 $alert-color-level: 0;
-
 $alert-bg-level:                    +3 !default;
 $alert-border-level:                +4 !default;
-$alert-color-level:                 6 !default;
 
 // Modals
 $modal-inner-padding: $padding-large-horizontal;

--- a/src/frontend/css/stylesheets/definitions/_variables.scss
+++ b/src/frontend/css/stylesheets/definitions/_variables.scss
@@ -106,6 +106,15 @@ $alert-border-width: 0;
 $alert-border-radius: 0;
 $alert-color-level: 0;
 
+$alert-bg-level:                    +10 !default;
+$alert-border-level:                +10 !default;
+$alert-color-level:                 6 !default;
+
+.alert {
+  color: #ffffff !important;
+}
+
+
 // Modals
 $modal-inner-padding: $padding-large-horizontal;
 $modal-header-padding-x: $padding-large-horizontal;

--- a/src/frontend/css/stylesheets/definitions/_variables.scss
+++ b/src/frontend/css/stylesheets/definitions/_variables.scss
@@ -8,6 +8,8 @@ $brand-danger:  #C14B3F;
 $brand-warning: #C57002;
 $brand-success: #719330;
 
+$warning: $brand-warning !default;
+
 $brand-secundary-hover: #294D94;
 
 $white: #FFF;
@@ -106,8 +108,8 @@ $alert-border-width: 0;
 $alert-border-radius: 0;
 $alert-color-level: 0;
 
-$alert-bg-level:                    +10 !default;
-$alert-border-level:                +10 !default;
+$alert-bg-level:                    +3 !default;
+$alert-border-level:                +4 !default;
 $alert-color-level:                 6 !default;
 
 .alert {


### PR DESCRIPTION

In '_variables.scss' redefined 2 variables that determine the the alert-box colour gradients and set them to be darker shades of the brand colours (as opposed to lighter)

In '_alert.scss' set the colour in '.alert' to white so it will override the default text colour (currently set to match brand colours)

In ' _dropdown_group-title'  remove original style / font and replaced with our h2 styling and colour