### PR TITLE
Uiux

### DIFF
--- a/src/frontend/components/alert/_alert.scss
+++ b/src/frontend/components/alert/_alert.scss
@@ -3,7 +3,7 @@
   align-items: center;
   margin-bottom: $padding-large-vertical;
   padding: $padding-base-horizontal;
-  color: $white;
+  color: #000000;
 
   &::before {
     @extend %icon-font;
@@ -34,16 +34,16 @@
 
   .alert-success::before {
     content: "\E804";
-    color: $white;
+    color: #000000;
   }
 
   .alert-info::before {
     content: "\E810";
-    color: $white;
+    color: #000000;
   }
 
   .alert-danger::before {
     content: "\E822";
-    color: $white;
+    color: #000000;
   }
 }

--- a/src/frontend/components/alert/_alert.scss
+++ b/src/frontend/components/alert/_alert.scss
@@ -3,7 +3,7 @@
   align-items: center;
   margin-bottom: $padding-large-vertical;
   padding: $padding-base-horizontal;
-  color: #000000;
+  color: $black;
 
   &::before {
     @extend %icon-font;
@@ -34,16 +34,16 @@
 
   .alert-success::before {
     content: "\E804";
-    color: #000000;
+    color: $black;
   }
 
   .alert-info::before {
     content: "\E810";
-    color: #000000;
+    color: $black;
   }
 
   .alert-danger::before {
     content: "\E822";
-    color: #000000;
+    color: $black;
   }
 }

--- a/src/frontend/css/stylesheets/definitions/_variables.scss
+++ b/src/frontend/css/stylesheets/definitions/_variables.scss
@@ -1,12 +1,12 @@
 // Colours
 $brand-primary: #4F427C;
-$brand-secundary: #006699;
+$brand-secundary: #007C88;
 $gradient-secundary: #1BADB8;
 $brand-tertiary: #F99D27;
 
-$brand-danger:  #C14B3F;
-$brand-warning: #C57002;
-$brand-success: #719330;
+$brand-danger:  #E30036;
+$brand-warning: #FFBB01;
+$brand-success: #18856B;
 
 $warning: $brand-warning;
 
@@ -107,8 +107,8 @@ $table-cell-padding: $padding-base-horizontal;
 $alert-border-width: 0;
 $alert-border-radius: 0;
 $alert-color-level: 0;
-$alert-bg-level: +3;
-$alert-border-level: +4;
+$alert-bg-level: -3;
+$alert-border-level: -2;
 
 // Modals
 $modal-inner-padding: $padding-large-horizontal;

--- a/src/frontend/css/stylesheets/definitions/_variables.scss
+++ b/src/frontend/css/stylesheets/definitions/_variables.scss
@@ -10,7 +10,7 @@ $brand-success: #18856B;
 
 $warning: $brand-warning;
 
-$brand-secundary-hover: #294D94;
+$brand-secundary-hover: $brand-primary;
 
 $white: #FFF;
 $black: #000;


### PR DESCRIPTION
Set alert text and icons from white to black.
Set the band colours to match the website 
Set the alert backgrounds and borders to be 2 - 3 shades lighter than the brand colours  (rather than 3 - 4 shades darker)
Set the on hover colour to match brand primary