### PR TITLE
Added Remove Alert button

### DIFF
--- a/lib/GADS.pm
+++ b/lib/GADS.pm
@@ -2296,20 +2296,28 @@ prefix '/:layout_name' => sub {
         }
 
         # Deal with any alert requests
-        if (param 'modal_alert')
-        {
+        if (param('modal_alert') || param('modal_remove')) {
+            my $success_message;
+            my $frequency = '';
+    
+            if (param('modal_remove')) {
+                $frequency = '';
+                $success_message = "The alert has been removed successfully";
+            }
+            if (param('modal_alert')) {
+                $frequency = param('frequency');
+                $success_message = "The alert has been saved successfully";
+            }
             my $alert_user = session('views_other_user_id') ? rset('User')->find(session('views_other_user_id')) : $user;
             my $alert = GADS::Alert->new(
                 user      => $alert_user,
                 layout    => $layout,
                 schema    => schema,
-                frequency => param('frequency'),
+                frequency => $frequency,
                 view_id   => param('view_id'),
             );
-            if (process(sub { $alert->write }))
-            {
-                return forwardHome(
-                    { success => "The alert has been saved successfully" }, $layout->identifier.'/data' );
+            if (process(sub { $alert->write })) {
+                return forwardHome({ success => $success_message }, $layout->identifier.'/data');
             }
         }
 

--- a/views/wizard/record_alert_me.tt
+++ b/views/wizard/record_alert_me.tt
@@ -1,7 +1,7 @@
 <div class="modal modal--form" id="[% modalId %]" tabindex="-1" role="dialog" aria-labelledby="[% modalId %]Label" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered " role="document">
     <div class="modal-content">
-      [% INCLUDE wizard/sub/modal_header.tt label="Configure alert for " _  v.name; %]
+      [% INCLUDE wizard/sub/modal_header.tt label="Configure alert for view:" _  v.name; %]
       
       <form method="post" class="">
         [% INCLUDE fields/hidden.tt name="csrf_token" value=csrf_token; %]
@@ -23,7 +23,6 @@
                   value       = NOT v.alert ? "" : v.alert.frequency
                   filter      = "html"
                   items       = [
-                    {id="", name="Never"},
                     {id="0", name="Instantly"},
                     {id="24", name="Every 24 hours"}
                   ];
@@ -40,10 +39,17 @@
               }]
               right_buttons = v.is_group ? [] : [{
                 type  = "submit"
+                class = "btn-danger"
+                name  = "modal_remove"
+                value = "submit"
+                label = "Remove"
+              }
+              {
+                type  = "submit"
                 class = "btn-default"
                 name  = "modal_alert"
                 value = "submit"
-                label = "Create alert"
+                label = "Create"
               }];
           %]
         </div>

--- a/views/wizard/record_alert_me.tt
+++ b/views/wizard/record_alert_me.tt
@@ -1,7 +1,7 @@
 <div class="modal modal--form" id="[% modalId %]" tabindex="-1" role="dialog" aria-labelledby="[% modalId %]Label" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered " role="document">
     <div class="modal-content">
-      [% INCLUDE wizard/sub/modal_header.tt label="Configure alert for view:" _  v.name; %]
+      [% INCLUDE wizard/sub/modal_header.tt label="Configure alert for view: " _  v.name; %]
       
       <form method="post" class="">
         [% INCLUDE fields/hidden.tt name="csrf_token" value=csrf_token; %]


### PR DESCRIPTION
- Removed 'Never option from the alert frequency options.

- Modified some of the displayed text for the alert modal header and buttons. 

- Added A button called 'Remove' to the alert modal that will replace the 'Never' option in the Alert drop-down.

- The 'Remove' button functions in exactly the same way as the create button but instead it's fixed to always write the 'Never' value in the alert frequency. (as well as having its own return message).

 