### PR TITLE
Changed calc type from input to auto adjust textarea

### DIFF
--- a/src/frontend/components/form-group/calc-fields/lib/component.js
+++ b/src/frontend/components/form-group/calc-fields/lib/component.js
@@ -62,10 +62,12 @@ class CalcFieldsComponent extends Component {
         var returnval = func.apply(first, vars)
 
         // Update the field holding the code's value
-        $field.find('input').val(returnval)
+        $field.find('textarea').val(returnval)
+        $field.find('textarea').text(returnval)
         // And trigger a change on its parent div to trigger any display
         // conditions
         $field.closest('.linkspace-field').trigger("change")
+        $field.find('textarea').trigger('change');
       });
     });
   }

--- a/src/frontend/components/form-group/calc-fields/lib/component.js
+++ b/src/frontend/components/form-group/calc-fields/lib/component.js
@@ -62,7 +62,6 @@ class CalcFieldsComponent extends Component {
         var returnval = func.apply(first, vars)
 
         // Update the field holding the code's value
-        $field.find('textarea').val(returnval)
         $field.find('textarea').text(returnval)
         // And trigger a change on its parent div to trigger any display
         // conditions

--- a/src/frontend/components/form-group/textarea/lib/component.js
+++ b/src/frontend/components/form-group/textarea/lib/component.js
@@ -9,7 +9,50 @@ class TextareaComponent extends Component {
       if (this.el.hasClass("textarea--required")) {
         initValidationOnField(this.el)
       }
+      
+      // Check if there is a textarea with the class 'auto-adjust'
+      const $autoAdjustTextarea = this.$el.find('textarea.auto-adjust');
+      if ($autoAdjustTextarea.length) {
+        this.adjustTextareaHeight();
+
+        $autoAdjustTextarea.on('change', () => {
+            this.adjustTextareaHeight();
+        });
+      }
+    } 
+    adjustTextareaHeight() {
+        const $textarea = this.$el.find('textarea.auto-adjust');
+
+        // Create a hidden div with just the text content
+        const $hiddenDiv = $('<div></div>').text($textarea.val()).css({
+            visibility: 'hidden',
+            position: 'absolute',
+            whiteSpace: 'pre-wrap',
+            padding: $textarea.css('padding'),
+            border: $textarea.css('border'),
+        });
+
+        // Add div to body
+        $('body').append($hiddenDiv);
+
+        // Calc the height + padding + border
+        const contentHeight = $hiddenDiv.outerHeight() / parseFloat(getComputedStyle($hiddenDiv[0]).fontSize);
+
+        // Remove hidden div
+        $hiddenDiv.remove();
+
+        const lineHeight = parseFloat($textarea.css('line-height')) / parseFloat($textarea.css('font-size'));
+        const minHeight = 2.5; // min height in REM
+        const maxHeight = 18;  // max height in REM
+
+        // Calculate the adjusted height
+        let adjustedHeight = (contentHeight < minHeight) ? contentHeight : contentHeight + lineHeight;
+
+        // Apply the maximum height constraint
+        adjustedHeight = Math.min(adjustedHeight, maxHeight);
+
+        // Set textarea height
+        $textarea.css('height', `${adjustedHeight}rem`);
     }
 }
-
 export default TextareaComponent

--- a/views/edit.tt
+++ b/views/edit.tt
@@ -952,20 +952,20 @@
     ELSIF col.type == "calc";
       FOREACH val IN editvalue.html_form;
         IF col.show_in_edit;
-          INCLUDE fields/input.tt
+          INCLUDE fields/textarea.tt
             id           = col.id
             name         = field
             label        = field_label
             label_checkbox_name = page == "bulk" ? "bulk_inc_" _ col.id : ''
             value        = val
             input_class  = ""
+            custom_classes = "auto-adjust"
             placeholder  = ""
             help_text    = col.description
             popover_body = col.helptext_html
             filter       = "html"
             is_readonly  = 1
-            hide_group   = 1
-            type         = "text";
+            hide_group   = 1;
         ELSE;
           INCLUDE fields/hidden.tt
             id     = col.id


### PR DESCRIPTION

- Changed the field type of calc from input to textarea.
- Changed the re-calc triggers to point at text-area instead of input.
- Added class + functionality to calc textareas,  to allow text-areas to resize based on the content returned by the Calc. (on load and on change).
