### PR TITLE
Fix for data tables

### DIFF
--- a/src/frontend/components/data-table/lib/component.js
+++ b/src/frontend/components/data-table/lib/component.js
@@ -46,6 +46,9 @@ class DataTableComponent extends Component {
     if (this.el.hasClass('table-account-requests')) {
       this.modal = $.find('#userModal')
       this.initClickableTable()
+      this.el.on('draw.dt', ()=> {
+        this.initClickableTable();
+      })
     }
 
     // Bind events to disclosure buttons and record-popup links on opening of child row
@@ -90,7 +93,11 @@ class DataTableComponent extends Component {
   }
 
   initClickableTable() {
-    const links = this.el.find('tbody td .link')
+    const links = $('tbody td .link')
+    // Remove all existing click events to prevent multiple bindings
+    links.off('click');
+    links.off('focus');
+    links.off('blur');
     links.on('click', (ev) => { this.handleClick(ev) })
     links.on('focus', (ev) => { this.toggleFocus(ev, true) })
     links.on('blur', (ev) => { this.toggleFocus(ev, false) })

--- a/src/frontend/components/data-table/lib/component.js
+++ b/src/frontend/components/data-table/lib/component.js
@@ -93,7 +93,7 @@ class DataTableComponent extends Component {
   }
 
   initClickableTable() {
-    const links = $('tbody td .link')
+    const links = this.el.find('tbody td .link')
     // Remove all existing click events to prevent multiple bindings
     links.off('click');
     links.off('focus');


### PR DESCRIPTION
Data tables were not adding click event on page or page-length change, this has now been fixed
