### PR TITLE
Account request notes fix

### DIFF
--- a/lib/GADS/Schema/Result/Site.pm
+++ b/lib/GADS/Schema/Result/Site.pm
@@ -280,9 +280,9 @@ sub user_fields
         },
         {
           name          => 'account_request_notes',
-          description   => $self->account_request_notes_name || 'User Request Notes',
+          description   => $self->account_request_notes_name || 'Notes',
           type          => 'textarea',
-          placeholder   => $self->account_request_notes_placeholder || 'User Request Notes',
+          placeholder   => $self->account_request_notes_placeholder || 'Notes',
         }
     );
     push @fields, {

--- a/lib/GADS/Schema/Result/Site.pm
+++ b/lib/GADS/Schema/Result/Site.pm
@@ -279,10 +279,10 @@ sub user_fields
             is_required => 1,
         },
         {
-          name          => 'notes',
-          description   => 'Notes',
+          name          => 'account_request_notes',
+          description   => $self->account_request_notes_name || 'User Request Notes',
           type          => 'textarea',
-          placeholder   => 'Notes'
+          placeholder   => $self->account_request_notes_placeholder || 'User Request Notes',
         }
     );
     push @fields, {
@@ -321,13 +321,7 @@ sub user_fields
         type        => 'freetext',
         placeholder => $self->register_freetext2_placeholder || $self->register_freetext2_name,
     } if $self->register_freetext2_name;
-    push @fields, {
-      name          => 'account_request_notes',
-      description   => $self->account_request_notes_name || 'Notes',
-      type          => 'textarea',
-      placeholder   => $self->account_request_notes_placeholder || 'Notes',
-    };
-
+    
     my $user_editable = decode_json($self->user_editable_fields || '{}');
 
     $_->{editable} = $user_editable->{$_->{name}} // 1 # Default to editable


### PR DESCRIPTION
There were 2 different fields within account request notes for "Notes" - it looks like one of them was added in error (as the "user" class has no "notes" field). As such, I have removed the "extra" one and fixed the naming and settings of the field that was producing an error.
