### PR TITLE
Double email sending fix

### DIFF
--- a/lib/GADS/Schema/Result/User.pm
+++ b/lib/GADS/Schema/Result/User.pm
@@ -866,7 +866,7 @@ sub update_user
 
     if(defined $params{account_request}) {
         $values->{account_request} = $params{account_request};
-        $request = 1;
+        $request = 1 if $self->account_request != $params{account_request};
     }
 
     my $original_username = $self->username;
@@ -974,7 +974,7 @@ sub update_user
 sub send_welcome_email
 {   my ($self, %params) = @_;
 
-    $params{email} = $self->email;
+    $params{email} = $self->email if !defined($params{email}) || $params{email} eq '';
     
     my %welcome_email = GADS::welcome_text(undef, %params);
 

--- a/lib/GADS/Schema/Result/User.pm
+++ b/lib/GADS/Schema/Result/User.pm
@@ -866,7 +866,7 @@ sub update_user
 
     if(defined $params{account_request}) {
         $values->{account_request} = $params{account_request};
-        $request = 1 if $self->account_request != $params{account_request};
+        $request = 1 if $self->account_request && !$params{account_request};
     }
 
     my $original_username = $self->username;
@@ -974,7 +974,7 @@ sub update_user
 sub send_welcome_email
 {   my ($self, %params) = @_;
 
-    $params{email} = $self->email if !defined($params{email}) || $params{email} eq '';
+    $params{email} ||= $self->email;
     
     my %welcome_email = GADS::welcome_text(undef, %params);
 


### PR DESCRIPTION
It was found that the value $params{account_request} was defined regardless of if it was a 1 or a 0, therefore a check is now present for if it is (currently) a 1 and this request is setting it to 0 (thus approving an account).
