### PR TITLE
Fix for file drag errors

### DIFF
--- a/src/frontend/components/form-group/input/lib/component.js
+++ b/src/frontend/components/form-group/input/lib/component.js
@@ -53,11 +53,14 @@ class InputComponent extends Component {
         });
         this.error = dropTarget.parent().find('.upload__error');
       } else throw new Error("Could not find file-upload element");
-      
+
       this.el.fileupload({
         dataType: "json",
         url: url,
         paramName: "file",
+        options: {
+          dropTarget: undefined
+        },
 
         submit: function() {
           $progressBarContainer.css("display", "block");
@@ -153,8 +156,7 @@ class InputComponent extends Component {
             if (request.readyState === 4 && request.status === 200) {
                 const data = JSON.parse(request.responseText);
                 self.addFileToField({ id: data.id, name: data.filename });
-            }
-            if(request.readyState === 4 && request.status <= 400){
+            } else if(request.readyState === 4 && request.status >= 400){
                 const response = fromJson(request.responseText);
                 if(response.is_error && response.message) self.showException(response.message);
                 else self.showException("An unexpected error occurred");

--- a/src/frontend/js/lib/util/filedrag/lib/filedrag.ts
+++ b/src/frontend/js/lib/util/filedrag/lib/filedrag.ts
@@ -45,6 +45,7 @@ class FileDrag {
             } else {
                 this.onDrop(e.originalEvent.dataTransfer.files[0]);
             }
+            $(document).trigger('drop');
             stopPropagation(e);
         });
     }
@@ -66,6 +67,13 @@ class FileDrag {
             hideElement(this.dropZone);
             showElement(this.el);
         });
+        $(document).on('drop', (e) => {
+            if (!this.dragging) return;
+            this.dragging = false;
+            hideElement(this.dropZone);
+            showElement(this.el);
+            stopPropagation(e);
+        })
         $(document).on('dragover', (e) => {
             if (!this.dragging) return;
             stopPropagation(e);


### PR DESCRIPTION
- Added options to stop Blueimp high-jacking document drop event
- Fixed incorrect direction for greater than arrow on `response >= 400`
- Fixed drop with multiple targets on screen not resetting correctly
