### PR TITLE
Added fullscreen control to audit table

### DIFF
--- a/src/frontend/components/data-table/lib/component.js
+++ b/src/frontend/components/data-table/lib/component.js
@@ -18,6 +18,7 @@ class DataTableComponent extends Component {
     this.el = $(this.element)
     this.hasCheckboxes = this.el.hasClass('table-selectable')
     this.hasClearState = this.el.hasClass('table-clear-state')
+    this.forceButtons = this.el.hasClass('table-force-buttons')
     this.searchParams = new URLSearchParams(window.location.search)
     this.base_url = this.el.data('href') ? this.el.data('href') : undefined
     this.initTable()
@@ -683,7 +684,7 @@ class DataTableComponent extends Component {
 
     $dataTableContainer.addClass('data-table__container--scrollable')
     // // See comments above regarding preventing multiple clicks
-    if(location.pathname!=='/settings/audit/')
+    if(!this.forceButtons)
       this.el.DataTable().button(0).disable();
     this.el.closest('.dataTables_wrapper').find('.btn-toggle-off').toggleClass(['btn-toggle', 'btn-toggle-off'])
 
@@ -695,7 +696,7 @@ class DataTableComponent extends Component {
     this.el.DataTable(conf)
     this.initializingTable = true
     // See comments above regarding preventing multiple clicks
-    if(location.pathname!=='/settings/audit/')
+    if(!this.forceButtons)
       this.el.DataTable().button(0).disable();
   }
 

--- a/src/frontend/components/data-table/lib/component.js
+++ b/src/frontend/components/data-table/lib/component.js
@@ -673,6 +673,11 @@ class DataTableComponent extends Component {
     return conf
   }
 
+  /*
+    For some reason, the current code that is present doesn't enable/disable the button as expected; it will disable the button, but will not re-enable the button.
+    I have tried manually changing the DOM, as well as the methods already present in the code, and I currently believe there is a bug within the DataTables button
+    code that is meaning that this won't change (although I am open to the fact that I am being a little slow and missing something glaringly obvious). - DR:24/01/2024
+  */
   enterFullScreenMode(conf) {
     this.originalResponsiveObj = conf.responsive
     conf.responsive = false

--- a/src/frontend/components/data-table/lib/component.js
+++ b/src/frontend/components/data-table/lib/component.js
@@ -683,7 +683,8 @@ class DataTableComponent extends Component {
 
     $dataTableContainer.addClass('data-table__container--scrollable')
     // // See comments above regarding preventing multiple clicks
-    this.el.DataTable().button(0).disable();
+    if(location.pathname!=='/settings/audit/')
+      this.el.DataTable().button(0).disable();
     this.el.closest('.dataTables_wrapper').find('.btn-toggle-off').toggleClass(['btn-toggle', 'btn-toggle-off'])
 
   }
@@ -694,7 +695,8 @@ class DataTableComponent extends Component {
     this.el.DataTable(conf)
     this.initializingTable = true
     // See comments above regarding preventing multiple clicks
-    this.el.DataTable().button(0).disable();
+    if(location.pathname!=='/settings/audit/')
+      this.el.DataTable().button(0).disable();
   }
 
   setFullscreenTableContainerHeight() {

--- a/views/admin/audit.tt
+++ b/views/admin/audit.tt
@@ -3,7 +3,7 @@
   # PROCESS snippets/datum.tt
 
   # prepare files table config
-  table_dom = "t";
+  table_dom = "Bt";
   table_show_all_records = 1;
 
   table_caption = "Table for audit log";

--- a/views/admin/audit.tt
+++ b/views/admin/audit.tt
@@ -3,10 +3,11 @@
   # PROCESS snippets/datum.tt
 
   # prepare files table config
-  table_dom = "Bt";
+  table_dom = 'Bt';
   table_show_all_records = 1;
 
   table_caption = "Table for audit log";
+  table_class = "table-force-buttons";
 
   table_columns = [{
     name = "ID"


### PR DESCRIPTION
- Had to change table display DOM to display button
- Had to modify behaviour based on location.path as the button wouldn't re-enable without (even though code was being called correctly).
