### PR TITLE
Fix for selects not populating on load

### DIFF
--- a/src/frontend/components/form-group/display-conditions/lib/component.js
+++ b/src/frontend/components/form-group/display-conditions/lib/component.js
@@ -14,7 +14,7 @@ class DisplayConditionsComponent extends Component {
     const filters = JSON.parse(Buffer.from(builderData.filters, 'base64'))
     if (!filters.length) return
 
-    this.el.on("afterCreateRuleFilters.queryBuilder", (e, rule) => {
+    this.el.on("afterUpdateRuleFilter.queryBuilder", (e, rule) => {
       const select= $(rule.$el.find('select'));
       if(!select || !select[0]) console.log("No select found");
       select.data("live-search","true");

--- a/src/frontend/components/form-group/filter/lib/component.js
+++ b/src/frontend/components/form-group/filter/lib/component.js
@@ -1,5 +1,6 @@
 import { Component } from 'component'
 import '@lol768/jquery-querybuilder-no-eval/dist/js/query-builder.standalone.min'
+import 'bootstrap-select/dist/js/bootstrap-select'
 import { logging } from 'logging'
 import TypeaheadBuilder from 'util/typeahead'
 import { map } from 'util/mapper/mapper'
@@ -97,6 +98,13 @@ class FilterComponent extends Component {
 
     if (!builderConfig.filters.length) return
     if (builderConfig.filterNotDone) this.makeUpdateFilter()
+
+    this.el.on("afterUpdateRuleFilter.queryBuilder", (e, rule) => {
+      const select= $(rule.$el.find('select'));
+      if(!select || !select[0]) console.log("No select found");
+      select.data("live-search","true");
+      select.selectpicker();
+    });
 
     $builderEl.queryBuilder({
       showPreviousValues: builderConfig.showPreviousValues,


### PR DESCRIPTION
Found that bootstrap-select was being applied to the wrong stage of the render pipeline for the querybuilder, meaning it had no value on reload. This has now been fixed.
