### PR TITLE
Fix for query-builder not showing correct values

### DIFF
--- a/src/frontend/components/form-group/display-conditions/lib/component.js
+++ b/src/frontend/components/form-group/display-conditions/lib/component.js
@@ -14,12 +14,12 @@ class DisplayConditionsComponent extends Component {
     const filters = JSON.parse(Buffer.from(builderData.filters, 'base64'))
     if (!filters.length) return
 
-    // this.el.on("afterUpdateRuleFilter.queryBuilder", (e, rule) => {
-    //   const select= $(rule.$el.find('select'));
-    //   if(!select || !select[0]) console.log("No select found");
-    //   select.data("live-search","true");
-    //   select.selectpicker();
-    // });
+    this.el.on("afterUpdateRuleFilter.queryBuilder", (e, rule) => {
+      const select= $(rule.$el.find(`select[name=${rule.id}_filter]`));
+      if(!select || !select[0]) console.log("No select found");
+      select.data("live-search","true");
+      select.selectpicker();
+    });
 
     this.el.queryBuilder({
       filters: filters,

--- a/src/frontend/components/form-group/display-conditions/lib/component.js
+++ b/src/frontend/components/form-group/display-conditions/lib/component.js
@@ -14,12 +14,12 @@ class DisplayConditionsComponent extends Component {
     const filters = JSON.parse(Buffer.from(builderData.filters, 'base64'))
     if (!filters.length) return
 
-    this.el.on("afterUpdateRuleFilter.queryBuilder", (e, rule) => {
-      const select= $(rule.$el.find('select'));
-      if(!select || !select[0]) console.log("No select found");
-      select.data("live-search","true");
-      select.selectpicker();
-    });
+    // this.el.on("afterUpdateRuleFilter.queryBuilder", (e, rule) => {
+    //   const select= $(rule.$el.find('select'));
+    //   if(!select || !select[0]) console.log("No select found");
+    //   select.data("live-search","true");
+    //   select.selectpicker();
+    // });
 
     this.el.queryBuilder({
       filters: filters,

--- a/src/frontend/components/form-group/filter/lib/component.js
+++ b/src/frontend/components/form-group/filter/lib/component.js
@@ -99,12 +99,12 @@ class FilterComponent extends Component {
     if (!builderConfig.filters.length) return
     if (builderConfig.filterNotDone) this.makeUpdateFilter()
 
-    // this.el.on("afterUpdateRuleFilter.queryBuilder", (e, rule) => {
-    //   const select= $(rule.$el.find('select'));
-    //   if(!select || !select[0]) console.log("No select found");
-    //   select.data("live-search","true");
-    //   select.selectpicker();
-    // });
+    this.el.on("afterUpdateRuleFilter.queryBuilder", (e, rule) => {
+      const select= $(rule.$el.find(`select[name=${rule.id}_filter]`));
+      if(!select || !select[0]) console.log("No select found");
+      select.data("live-search","true");
+      select.selectpicker();
+    });
 
     $builderEl.queryBuilder({
       showPreviousValues: builderConfig.showPreviousValues,

--- a/src/frontend/components/form-group/filter/lib/component.js
+++ b/src/frontend/components/form-group/filter/lib/component.js
@@ -99,12 +99,12 @@ class FilterComponent extends Component {
     if (!builderConfig.filters.length) return
     if (builderConfig.filterNotDone) this.makeUpdateFilter()
 
-    this.el.on("afterUpdateRuleFilter.queryBuilder", (e, rule) => {
-      const select= $(rule.$el.find('select'));
-      if(!select || !select[0]) console.log("No select found");
-      select.data("live-search","true");
-      select.selectpicker();
-    });
+    // this.el.on("afterUpdateRuleFilter.queryBuilder", (e, rule) => {
+    //   const select= $(rule.$el.find('select'));
+    //   if(!select || !select[0]) console.log("No select found");
+    //   select.data("live-search","true");
+    //   select.selectpicker();
+    // });
 
     $builderEl.queryBuilder({
       showPreviousValues: builderConfig.showPreviousValues,


### PR DESCRIPTION
Querybuilder is not showing correct values for the filter action (i.e. not equal, is empty, etc.) - for now as an immediate fix to users, the typeahead and bootstrap-select code has been removed to be changed and fixed for next release.
