### PR TITLE
Fix for incorrect optimisation of Plotly JS

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,5 +16,8 @@
     ],
     "@babel/preset-typescript",
     "@babel/preset-react"
+  ],
+  "ignore": [
+    "src/frontend/js/lib/plotly/*.js",
   ]
 }


### PR DESCRIPTION
Optimisation through Babel was causing globes to not work, Plotly has been removed from the optimisation process - tested and working locally
