### PR TITLE
Changes to Download Options

### DIFF
--- a/src/frontend/css/stylesheets/base/_global.scss
+++ b/src/frontend/css/stylesheets/base/_global.scss
@@ -94,3 +94,11 @@ table.table-bordered {
     border: solid 1px $gray;
   }
 }
+
+.dropdown-menu {
+  li.spacer {
+    border-bottom: $border-width solid $gray;
+    width: 98%;
+    margin: 0 auto;
+  }
+}

--- a/views/snippets/button_list.tt
+++ b/views/snippets/button_list.tt
@@ -82,8 +82,9 @@
                     target="_blank">
                       [% item.label || item.name | html %]
                   </a>
-                [% END %]
               </li>
+              [% END %]
+              [% INCLUDE extension/record_edit_extra.tt %]
             </ul>
           </div>
         </div>

--- a/views/snippets/header_table_form.tt
+++ b/views/snippets/header_table_form.tt
@@ -68,8 +68,6 @@
               });
             END;
 
-            INCLUDE 'extension/record_edit_extra.tt';
-
             IF user.permission.link;
               record_edit_buttons.push({
                 type          = "link",


### PR DESCRIPTION
- Created CSS for separator
- Moved `record_edit_extra.tt` out of `header_table_form.tt` and into `button_list.tt` in order to allow download options in extensions to display in correct (new) place

**This edit will break GADS-extensions - please install newer version in order to ensure correct display**
