### PR TITLE
Fixed bug on fullscreen button

### DIFF
--- a/src/frontend/components/data-table/lib/component.js
+++ b/src/frontend/components/data-table/lib/component.js
@@ -700,7 +700,7 @@ class DataTableComponent extends Component {
     }
 
     // Toggle the full screen button
-    $(buttonElement.target).toggleClass(['btn-toggle', 'btn-toggle-off'])
+    $(fullScreenButton).toggleClass(['btn-toggle', 'btn-toggle-off'])
   }
 
   exitFullScreenMode(conf) {


### PR DESCRIPTION
Span in fullscreen button was having classes erroneously applied, this has now been fixed.
