### PR TITLE
Fix the minimum version required of PDF::Table

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -52,8 +52,7 @@ our %prereq_pm = (
     'Net::OAuth2::AuthorizationServer::PasswordGrant' => 0,
     'Net::SAML2'                                => 0,
     'Plack'                                     => '1.0047',
-    # Not depended on directly, but needed for features used via CtrlO::PDF
-    'PDF::Table'                                => '0.11.0',
+    'PDF::Table'                                => '1.006',
     'Session::Token'                            => 0,
     'Starman'                                   => 0,
     'String::CamelCase'                         => 0,


### PR DESCRIPTION
Commit 449838bf88 changed the minimum version of PDF::Table required by GADS::Schema::Result::Report, but did not state this in the Makefile.PL. That commit does not say why we require this newer version.

GADS::Record still requires a minimum version of "0.11.0" which probably also needs updating for consistency, but without understanding why GADS::Schema::Result::Report needs a newer version, I don't know.