### PR TITLE
Added `browserslist` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,5 +93,11 @@
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.11.1",
     "webpack-manifest-plugin": "^5.0.0"
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "Firefox ESR",
+    "not dead",
+    "IE 11"
+  ]
 }


### PR DESCRIPTION
Slightly concerned that the compatibility isn't necessarily in place for the `import().then()` used in the code for chunking (this is _not_ IE11 compatible) - original config allowed this to (possibly) pass through as any browser with less than 0.2% share should be ignored (IE has less than this according to [caniuse.com](http://caniuse.com))
