### PR TITLE
Allow setting of port on launch through environment variable

### DIFF
--- a/bin/app.pl
+++ b/bin/app.pl
@@ -4,4 +4,8 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 
 use GADS;
+use Dancer2;
+
+set port => ($ENV{PORT} || 3000);
+
 GADS->dance;


### PR DESCRIPTION
Insignificant change, but I've used it a couple of times when I've had multiple instances running locally