### PR TITLE
Fix for datatable console error

### DIFF
--- a/src/frontend/components/data-table/lib/component.js
+++ b/src/frontend/components/data-table/lib/component.js
@@ -607,6 +607,8 @@ class DataTableComponent extends Component {
 
       this.json = json || undefined
 
+      const self = this
+
       if (this.initializingTable) {
         dataTable.columns().every(function(index) {
           const column = this


### PR DESCRIPTION
Invalid scoping and incorrect parameters caused `undefined` error
