### PR TITLE
Fix for scoping error on AJAX request

### DIFF
--- a/src/frontend/components/form-group/select-widget/lib/component.js
+++ b/src/frontend/components/form-group/select-widget/lib/component.js
@@ -465,7 +465,7 @@ class SelectWidgetComponent extends Component {
     // If we cancel this particular loop, then we don't want to remove the
     // spinner if another one has since started running
     let hideSpinner = true
-    $.getJSON(url, function(data) {
+    $.getJSON(url, (data) => {
       if (data.error === 0) {
         if (myLoad != this.loadCounter) { // A new one has started running
           hideSpinner = false // Don't remove the spinner on completion


### PR DESCRIPTION
Found ajax function was using `function` keyword rather than arrow function, meaning that the scoping was changing the scope of the `this` variable.
