### PR TITLE
Fixed bug in arrow display

### DIFF
--- a/src/frontend/components/popover/_popover.scss
+++ b/src/frontend/components/popover/_popover.scss
@@ -35,7 +35,7 @@
 
     display: none;
     position: absolute;
-    z-index: 2;
+    z-index: 1000;
     bottom: -1px;
     left: 0;
     width: 1rem;


### PR DESCRIPTION
z-index was incorrect on the popover arrow, causing it to display with a border incorrectly, this has now been rectified
