### PR TITLE
Typeahead Fix

### DIFF
--- a/src/frontend/js/lib/util/typeahead/lib/Typeahead.ts
+++ b/src/frontend/js/lib/util/typeahead/lib/Typeahead.ts
@@ -43,7 +43,7 @@ export class Typeahead {
         this.$input.typeahead({
             hint: false,
             highlight: false,
-            minLength: 0
+            minLength: 1
         }, {
             name: name,
             source: bloodhound,


### PR DESCRIPTION
Made TypeAhead use 1+ characters before suggestions. This is to mitigate issue with view filters.
