### PR TITLE
Fix WebDriver tests

### DIFF
--- a/webdriver/t/lib/Test/GADSDriver.pm
+++ b/webdriver/t/lib/Test/GADSDriver.pm
@@ -501,7 +501,7 @@ sub assert_on_manage_tables_page {
     $self->_assert_on_page(
         $name,
         { selector => 'h1', text => 'Tables' },
-        { selector => 'th.sorting', match => '\A(?i)Table\s+\z' },
+        { selector => '.nav__link--active', text => 'Tables' },
     );
 
     $test->release;


### PR DESCRIPTION
At some point between 3519813b and 217c0daa these tests began failing. From a quick glance, I don't understand why.  The tests failed as follows:
```
  not ok 23 - The manage tables page is visible
  # Failed test 'The manage tables page is visible'
  # at webdriver/t/create_view.t line 290.
  # No elements matching 'th.sorting' found
```
The "Manage Tables" page contains no element matching the "th.sorting" selector so it makes sense that this test fails.  Instead of checking for that, check that the active navigation link contains the word "Tables".