### PR TITLE
Fix for duplicate field selection

### DIFF
--- a/views/historic_purge/initial.tt
+++ b/views/historic_purge/initial.tt
@@ -30,7 +30,7 @@
             label       = ""
             sub_field   = "fields/sub/checkbox.tt"
             sub_params  = {
-                id => "dt_checkbox_" _ column_name
+                id => "dt_checkbox_" _ column_id
                 name => "column_id"
                 label => column_name
                 checked => columns_selected.$column_id


### PR DESCRIPTION
As the labels for the fields were driving the checkboxes which meant that duplicate names were limiting the selection
