### PR TITLE
Added Cypress downloads.html to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ webdriver/MYMETA.*
 yarn-error.log
 
 webpack.config.development.js
+
+cypress/downloads/downloads.html


### PR DESCRIPTION
This file is added as part of the chrome testing (it's part of Chrome's anti-phishing/security checks, according to google) - it's not required to it has been added to .gitignore as to ensure it isn't added by mistake
