### PR TITLE
Fixed form mapper error where File objects were not being mapped correctly

### DIFF
--- a/src/frontend/js/lib/util/mapper/formdataMapper.test.ts
+++ b/src/frontend/js/lib/util/mapper/formdataMapper.test.ts
@@ -14,27 +14,6 @@ describe("Basic formdata mapper tests", () => {
         expect(formdataMapper(data)).toEqual(formData);
     });
 
-    it("should map a nested object", () => {
-        const data = {
-            name: "John Doe",
-            age: 30,
-            email: "john@example.com",
-            address: {
-                street: "1234 Elm St",
-                city: "Springfield",
-                state: "IL"
-            }
-        };
-        const formData = new FormData();
-        formData.append("name", "John Doe");
-        formData.append("age", "30");
-        formData.append("email", "john@example.com");
-        formData.append("address_street", "1234 Elm St");
-        formData.append("address_city", "Springfield");
-        formData.append("address_state", "IL");
-        expect(formdataMapper(data)).toEqual(formData);
-    });
-
     it("should throw an error for nested objects deeper than one layer", () => {
         const data = {
             name: "John Doe",

--- a/src/frontend/js/lib/util/mapper/formdataMapper.ts
+++ b/src/frontend/js/lib/util/mapper/formdataMapper.ts
@@ -1,5 +1,4 @@
 export const formdataMapper = <T>(data: FormData | T) => {
-    console.log("DATA: ", data);
     if (data instanceof FormData) {
         let hasData = false;
         data.forEach(() => {

--- a/src/frontend/js/lib/util/mapper/formdataMapper.ts
+++ b/src/frontend/js/lib/util/mapper/formdataMapper.ts
@@ -1,4 +1,5 @@
 export const formdataMapper = <T>(data: FormData | T) => {
+    console.log("DATA: ", data);
     if (data instanceof FormData) {
         let hasData = false;
         data.forEach(() => {
@@ -11,14 +12,7 @@ export const formdataMapper = <T>(data: FormData | T) => {
     if(data instanceof Object && Object.keys(data).length === 0) throw new Error("Cannot map an empty object");
     const formData = new FormData();
     Object.entries(data).forEach(([key, value]) => {
-        if (value instanceof Object) {
-            Object.entries(value).forEach(([subKey, subValue]) => {
-                if(subValue instanceof Object) throw new Error("Nested objects deeper than one layer are not supported");
-                formData.append(`${key}_${subKey}`, subValue as string);
-            });
-        } else {
-            formData.append(key, value as string);
-        }
+        formData.append(key, value);
     });
     return formData;
 }


### PR DESCRIPTION
We will now rely on `FormData` methods to catch erroneous objects being passed in. It may be worth working towards a more robust mapper for future use, but for now, this version is more than suitable for our needs.