### PR TITLE
File rename upload

### DIFF
--- a/lib/GADS.pm
+++ b/lib/GADS.pm
@@ -1739,9 +1739,9 @@ post '/file/:id?' => require_login sub {
 # Use api route to ensure errors are returned as JSON
 post '/api/file/?' => require_login sub {
 
-    if(my rename_id=param('rename')) {
+    if(my $rename_id=param('rename')) {
         my $file = schema->resultset('Fileval')->find($rename_id);
-        $file->update({name=>param('name')});
+        $file->update({name=>param('filename')});
         return encode_json({
             id => $file->id,
             name => $file->name,

--- a/lib/GADS.pm
+++ b/lib/GADS.pm
@@ -1739,6 +1739,16 @@ post '/file/:id?' => require_login sub {
 # Use api route to ensure errors are returned as JSON
 post '/api/file/?' => require_login sub {
 
+    if(my rename_id=param('rename')) {
+        my $file = schema->resultset('Fileval')->find($rename_id);
+        $file->update({name=>param('name')});
+        return encode_json({
+            id => $file->id,
+            name => $file->name,
+            is_ok => 1,
+        });
+    }
+
     if (my $delete_id = param('delete'))
     {
         error __"You do not have permission to delete files"

--- a/src/frontend/components/form-group/input/lib/documentComponent.ts
+++ b/src/frontend/components/form-group/input/lib/documentComponent.ts
@@ -8,22 +8,26 @@ interface FileData {
     filename: string;
 }
 
+interface RenameResponse {
+    id: number | string;
+    name: string;
+    is_ok: boolean;
+}
+
 class DocumentComponent {
     readonly type = 'document';
-    el: JQuery<HTMLElement>;
+    readonly el: JQuery<HTMLElement>;
     fileInput: JQuery<HTMLInputElement>;
     error: JQuery<HTMLElement>;
 
     constructor(el: JQuery<HTMLElement> | HTMLElement) {
-        this.el = el instanceof HTMLElement ? $(el) : el;
+        this.el = $(el);
         this.fileInput = this.el.find<HTMLInputElement>('.form-control-file');
         this.error = this.el.find('.upload__error');
     }
 
     init() {
         const url = this.el.data('fileupload-url');
-        const $progressBarContainer = this.el.find('.progress-bar__container');
-        const $progressBarProgress = this.el.find('.progress-bar__progress');
 
         const tokenField = this.el.closest('form').find('input[name="csrf_token"]');
         const csrf_token = tokenField.val() as string;
@@ -31,7 +35,7 @@ class DocumentComponent {
 
         if (dropTarget) {
             const dragOptions = { allowMultiple: false };
-            (<any>dropTarget).filedrag(dragOptions).on('onFileDrop', (_ev: JQuery.DropEvent, file: File) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+            dropTarget.filedrag(dragOptions).on('onFileDrop', (_ev: JQuery.DropEvent, file: File) => {
                 this.handleAjaxUpload(url, csrf_token, file);
             });
         } else {
@@ -46,12 +50,17 @@ class DocumentComponent {
             const file = ev.target.files![0];
             const formData = formdataMapper({ file, csrf_token });
 
-            upload<FileData>(url, formData, 'POST', this.updateProgress).then((data) => {
+            upload<FileData>(url, formData, 'POST', (loaded, total) => {
+                if (!this.el.data('multivalue')) {
+                    const uploadProgression = Math.round((loaded / total) * 10000) / 100 + '%';
+                    this.el.find('.progress-bar__percentage').html(uploadProgression);
+                    this.el.find('.progress-bar__progress').css('width', uploadProgression);
+                }
+            }).then((data) => {
                 this.addFileToField({ id: data.id, name: data.filename });
             }).catch((error) => {
-                $progressBarProgress.css('width', '100%');
-                $progressBarContainer.addClass('progress-bar__container--fail');
                 this.showException(error);
+                return;
             });
         });
     }
@@ -62,13 +71,17 @@ class DocumentComponent {
 
         const fileData = formdataMapper({ file, csrf_token });
 
-        upload<FileData>(uri, fileData, 'POST', this.updateProgress)
-            .then((data) => {
-                this.addFileToField({ id: data.id, name: data.filename });
-            })
-            .catch((e) => {
-                this.showException(e);
-            });
+        upload<FileData>(uri, fileData, 'POST', (loaded, total) => {
+            if (!this.el.data('multivalue')) {
+                const uploadProgression = Math.round((loaded / total) * 10000) / 100 + '%';
+                this.el.find('.progress-bar__percentage').html(uploadProgression);
+                this.el.find('.progress-bar__progress').css('width', uploadProgression);
+            }
+        }).then((data) => {
+            this.addFileToField({ id: data.id, name: data.filename });
+        }).catch((e) => {
+            this.showException(e);
+        });
     }
 
     addFileToField(file: { id: number | string; name: string }) {
@@ -77,17 +90,31 @@ class DocumentComponent {
         const fileId = file.id;
         const fileName = file.name;
         const field = $fieldset.find('.input--file').data('field');
+        const csrf_token = $('body').data('csrf');
 
-        if (!this.el.data('multivalue')) {
-            $ul.empty();
-        }
+        if (!this.el || !this.el.length || !this.el.data('multivalue')) $ul.empty();
 
         const $li = $(`
+            <li class="list__item">
+                <span class="list__key sr-only">
+                    <label for="file-rename-${fileId}">Rename file</label>
+                </span>
+                <span class="list__value">
+                    <span class="row">
+                        <span class="col-10">                
+                            <input type="text" id="file-rename-${fileId}" name="file-rename-${fileId}" value="${fileName}" class="input input--text form-control">
+                        </span>
+                        <span class="col-2">
+                            <button id="rename-${fileId}" class="btn btn-default" data-file-id="${fileId}" data-original-name="${fileName}" type="button">Rename</button>
+                        </span>
+                    </span>
+                </span>
+            </li>
             <li class="list__item">
                 <span class="list__key">
                     <input type="checkbox" id="file-${fileId}" name="${field}" value="${fileId}" aria-label="${fileName}" data-filename="${fileName}" checked>
                 </span>
-                <span class="list__value">Include file. Current file name:<a class="link link--plain" href="/file/${fileId}">${fileName}</a>.</span>
+                <span class="list__value">Include File. Current file name: <a id="current-${fileId}" class="link link--plain" href="/file/${fileId}">${fileName}</a>.</span>
             </li>
         `);
 
@@ -95,19 +122,36 @@ class DocumentComponent {
         $ul.closest('.linkspace-field').trigger('change');
         validateCheckboxGroup($fieldset.find('.list'));
         $fieldset.find('input[type="file"]').removeAttr('required');
+        const button = `#rename-${fileId}`;
+        const $button = $(button);
+        console.log(`Adding click to ${button}`);
+
+        $(button).on('click', () => this.handleRename($button, csrf_token));
+    }
+
+    private handleRename($button: JQuery<HTMLElement>, csrf_token: string) { // for some reason using the ev.target doesn't allow for changing of the data attribute - I don't know why, so I've used the button itself
+        const fileId = $button.data('file-id');
+        const originalName = $button.data('original-name');
+        const ext = "." + originalName.split('.').pop();
+        const newName = $(`#file-rename-${fileId}`).val() as string;
+        if ((newName.endsWith(ext) ? newName : newName + ext) === originalName) return;
+        const url = `/api/file`;
+        const data = formdataMapper({ csrf_token, rename: fileId, filename: newName.endsWith(ext) ? newName : newName + ext });
+        upload<RenameResponse>(url, data, 'POST').then((data) => {
+            console.log("renamed", data);
+            console.log("BUTTON", $button)
+            $button.data('original-name', data.name);
+            $(`#current-${fileId}`).text(data.name);
+        }).catch((error) => {
+            this.showException(error);
+        });
     }
 
     showException(e: string | Error) {
+        this.el.find('.progress-bar__container').css('width', '100%');
+        this.el.find('.progress-bar__progress').addClass('progress-bar__container--fail');
         this.error.html(e instanceof Error ? e.message : e);
         showElement(this.error);
-    }
-
-    private updateProgress(loaded: number, total: number) {
-        if (!this.el.data('multivalue')) {
-            const uploadProgression = Math.round((loaded / total) * 10000) / 100 + '%';
-            this.el.find('.progress-bar__percentage').html(uploadProgression);
-            this.el.find('.progress-bar__progress').css('width', uploadProgression);
-        }
     }
 }
 

--- a/src/frontend/js/lib/util/filedrag/index.d.ts
+++ b/src/frontend/js/lib/util/filedrag/index.d.ts
@@ -1,0 +1,9 @@
+import { FileDragOptions } from "./lib/filedrag";
+
+declare global {
+    interface JQuery<TElement = HTMLElement> {
+        filedrag(options: FileDragOptions): JQuery<TElement>;
+    }
+}
+
+export {}

--- a/src/frontend/js/lib/util/filedrag/lib/filedrag.ts
+++ b/src/frontend/js/lib/util/filedrag/lib/filedrag.ts
@@ -1,6 +1,6 @@
 import { hideElement, showElement } from "util/common";
 
-interface FileDragOptions {
+export interface FileDragOptions {
     allowMultiple?: boolean;
     debug?: boolean;
 }

--- a/src/frontend/js/lib/util/mapper/formdataMapper.test.ts
+++ b/src/frontend/js/lib/util/mapper/formdataMapper.test.ts
@@ -14,27 +14,6 @@ describe("Basic formdata mapper tests", () => {
         expect(formdataMapper(data)).toEqual(formData);
     });
 
-    it("should map a nested object", () => {
-        const data = {
-            name: "John Doe",
-            age: 30,
-            email: "john@example.com",
-            address: {
-                street: "1234 Elm St",
-                city: "Springfield",
-                state: "IL"
-            }
-        };
-        const formData = new FormData();
-        formData.append("name", "John Doe");
-        formData.append("age", "30");
-        formData.append("email", "john@example.com");
-        formData.append("address_street", "1234 Elm St");
-        formData.append("address_city", "Springfield");
-        formData.append("address_state", "IL");
-        expect(formdataMapper(data)).toEqual(formData);
-    });
-
     it("should throw an error for nested objects deeper than one layer", () => {
         const data = {
             name: "John Doe",

--- a/src/frontend/js/lib/util/mapper/formdataMapper.test.ts
+++ b/src/frontend/js/lib/util/mapper/formdataMapper.test.ts
@@ -14,23 +14,6 @@ describe("Basic formdata mapper tests", () => {
         expect(formdataMapper(data)).toEqual(formData);
     });
 
-    it("should throw an error for nested objects deeper than one layer", () => {
-        const data = {
-            name: "John Doe",
-            age: 30,
-            email: "john@example.com",
-            address: {
-                street: "1234 Elm St",
-                city: "Springfield",
-                state: "IL",
-                zip: {
-                    code: 62701
-                }
-            }
-        };
-        expect(() => formdataMapper(data)).toThrow(new Error("Nested objects deeper than one layer are not supported"));
-    });
-
     it('should return the same FormData object if it is passed in', () => {
         const formData = new FormData();
         formData.append("name", "John Doe");

--- a/src/frontend/js/lib/util/mapper/formdataMapper.ts
+++ b/src/frontend/js/lib/util/mapper/formdataMapper.ts
@@ -1,5 +1,4 @@
 export const formdataMapper = <T>(data: FormData | T) => {
-    console.log("DATA: ", data);
     if (data instanceof FormData) {
         let hasData = false;
         data.forEach(() => {

--- a/src/frontend/js/lib/util/mapper/formdataMapper.ts
+++ b/src/frontend/js/lib/util/mapper/formdataMapper.ts
@@ -1,4 +1,5 @@
 export const formdataMapper = <T>(data: FormData | T) => {
+    console.log("DATA: ", data);
     if (data instanceof FormData) {
         let hasData = false;
         data.forEach(() => {
@@ -11,14 +12,7 @@ export const formdataMapper = <T>(data: FormData | T) => {
     if(data instanceof Object && Object.keys(data).length === 0) throw new Error("Cannot map an empty object");
     const formData = new FormData();
     Object.entries(data).forEach(([key, value]) => {
-        if (value instanceof Object) {
-            Object.entries(value).forEach(([subKey, subValue]) => {
-                if(subValue instanceof Object) throw new Error("Nested objects deeper than one layer are not supported");
-                formData.append(`${key}_${subKey}`, subValue as string);
-            });
-        } else {
-            formData.append(key, value as string);
-        }
+        formData.append(key, value);
     });
     return formData;
 }


### PR DESCRIPTION
- Removed failing test
- Added definitions for filedrag plugin - this is to ease future development
- Added check for renaming in API endpoint as well as functionality to perform the rename
- Cleaned up some code within `DocumentComponent`, namely:
    - made `el` property `readonly` - this was because I believed it was being overwritten somewhere (see next point)
    - the `updateProgress` function wasn't firing correctly and couldn't find the element it was supposed to be linked to - this has been removed (although it now means the code isn't as DRY)
    - Changed the `showerror` function in an attempt to make result consistent across calls
- Added input and button for document renaming and implemented logic

As noted in the code - for some reason I wasn't able to modify the `original-name` data attribute within the component using `event.target` when the rename function was called so I had to pass the button in directly - frankly, TypeScript appears to have dropped the ball somewhere on this - I would upgrade the version of TS, Babel, Webpack, etc. but I'm not insane enough to go down that rabbit-hole - this is deemed the lesser of two evils in my opinion.