### PR TITLE
Fix for user permissions not saving

### DIFF
--- a/views/snippets/user_column_permissions.tt
+++ b/views/snippets/user_column_permissions.tt
@@ -51,7 +51,7 @@
     INCLUDE fields/checkbox_list.tt
         fieldset_name = "permissions"
         list_class = list_class
-        name = "permission"
+        name = "permissions"
         label = "User's system-wide permissions"
         items = [{
           id = "superadmin",


### PR DESCRIPTION
Typo in `wizz?ard` was causing permissions to not be saved
