### PR TITLE
Fix for as_integer causing panic [B: 1741]

### DIFF
--- a/lib/GADS/Datum/Integer.pm
+++ b/lib/GADS/Datum/Integer.pm
@@ -123,7 +123,14 @@ sub as_string
     join ', ', @values;
 }
 
-sub as_integer { panic "No longer implemented" }
+sub as_integer {
+    my $self   = shift;
+    my @values = grep { defined } @{ $self->values };
+    return 0 if !@values;
+    my @ints = map { $_ + 0 } grep { /^\d+$/ } @values if @values;
+    return 0 if !@ints;
+    \@ints;
+}
 
 sub _build_for_code
 {   my ($self, %options) = @_;


### PR DESCRIPTION
Due to extensions using hashinflater to create reports, the panic on `GADS::Datum::Integer->as_integer` was triggering on generating reports for specific systems - this has been put back in with a view to fix this issue.