### PR TITLE
Fix for datatables loading graphic displaying in the incorrect place [B: 1738]

### DIFF
--- a/src/frontend/components/data-table/_data-table.scss
+++ b/src/frontend/components/data-table/_data-table.scss
@@ -351,7 +351,8 @@ div.dataTables_wrapper div.dataTables_filter input.form-control {
   }
 }
 
-div.dataTables_wrapper div.dataTables_processing {
+div.dataTables_wrapper div.dataTables_processing,
+div.td-container div.dt-processing {
   top: 10rem;
 }
 


### PR DESCRIPTION
Due to upgrade on DT to 2.0, the class names for this component had changed; this particular element had been missed in the SCSS changes and should now be corrected with this PR.