### PR TITLE
Timeline triage

### DIFF
--- a/lib/GADS/Timeline.pm
+++ b/lib/GADS/Timeline.pm
@@ -428,6 +428,11 @@ sub _build_items
 
         $self->_set_display_to($oldest)
             if $oldest > ($self->display_to || AT_BIGBANG);
+
+        if(scalar(@items) > 1000) # XXX Arbitrary limit
+        {   warning __"Too many items to display on the timeline - showing first 1000 results";
+            last;
+        }
     }
 
     if(!@items)

--- a/src/frontend/components/timeline/lib/component.js
+++ b/src/frontend/components/timeline/lib/component.js
@@ -12,6 +12,7 @@ class TimelineComponent extends Component {
         this.el = $(this.element)
 
         this.initTimeline()
+        this.tl_request = undefined
     }
 
     initTimeline() {
@@ -257,12 +258,13 @@ class TimelineComponent extends Component {
         if (is_dashboard) {
           url = url + '&dashboard=1&view=' + $container.data('view')
         }
-        $.ajax({
-          async: false,
+        if(self.tl_request) self.tl_request.abort()
+        self.tl_request = $.ajax({
           url: url,
           dataType: 'json',
           success: function(data) {
             items.add(data)
+            self.tl_request = undefined
           }
         })
       }


### PR DESCRIPTION
This PR is purely to address the timeline making the system unresponsive. The fix:

- Sets an (arbitrary) limit on the number of items one request can return - in testing on a copy system it was found that this gave us an average wait time of approx 1min when reaching said limit
- Runs the request to update the timeline asynchronously, meaning the system remains responsive, and navigation away from the page is still possible should the timeline be selected by mistake
- Cancels requests should another be required before it has completed

As stated, this is currently a triage operation, this is not expected to be a permanent fix. A full requirement shall be discussed and implemented for v2.7 as far as is feasible.