### PR TITLE
Added missing  sub

### DIFF
--- a/lib/GADS/Column/Tree.pm
+++ b/lib/GADS/Column/Tree.pm
@@ -35,6 +35,11 @@ sub DESTROY
     $self->_root->delete_tree if $self->_has_tree && $self->_root;
 }
 
+sub values_for_timeline
+{   my $self=shift;
+    return map $_->{value}, @{$self->enumvals};
+}
+
 sub value_field_as_index
 {   return 'id';
 }


### PR DESCRIPTION
Sub `values_for_timeline` was missing from `lib/GADS/tree.pm` and caused a panic when the show all values in the timeline config was selected.