### PR TITLE
Fix for chronology on curvals [B:1783]

### DIFF
--- a/lib/GADS/Column/Curcommon.pm
+++ b/lib/GADS/Column/Curcommon.pm
@@ -54,6 +54,10 @@ has override_permissions => (
     predicated => 1,
 );
 
+has chronology => (
+    is => 'rw',
+);
+
 has limit_rows => (
     is      => 'rw',
     isa     => Maybe[Int],
@@ -61,6 +65,7 @@ has limit_rows => (
     builder => sub {
         my $self = shift;
         return 0 unless $self->has_options;
+        return 0 if $self->chronology;
         $self->options->{limit_rows};
     },
     coerce  => sub { $_[0] ? int $_[0] : undef },

--- a/lib/GADS/Record.pm
+++ b/lib/GADS/Record.pm
@@ -1051,6 +1051,7 @@ sub _find
                 records      => [$record],
                 is_draft     => $find{draftuser_id},
                 already_seen => $records->already_seen,
+                chronology   => 1,
             );
             my @changed;
             foreach my $column (@{$record->columns_render})

--- a/lib/GADS/Records.pm
+++ b/lib/GADS/Records.pm
@@ -1326,6 +1326,7 @@ sub fetch_multivalues
         my @cols = ($column);
         if ($column->type eq 'curval')
         {
+            $column->chronology(1) if $params{chronology};
             $parent_field = $column->field;
             push @cols, @{$column->curval_fields_multivalue(already_seen => $already_seen)};
             # Flag any curval multivalue fields as also requiring fetching


### PR DESCRIPTION
This fix means the curvals will stop showing as added or removed when they "drop off" the view due to view limits.