### PR TITLE
Removed count parameter from download options [B:1798]

### DIFF
--- a/views/navigation/dropdown_actions.tt
+++ b/views/navigation/dropdown_actions.tt
@@ -61,7 +61,7 @@
     });
   END;
 
-  IF viewtype == "table" AND count AND layout_obj.user_can("download");
+  IF viewtype == "table" AND layout_obj.user_can("download");
     bulk_action_groups.0.items.push({
       id     = "",
       class  = "",

--- a/views/navigation/dropdown_actions.tt
+++ b/views/navigation/dropdown_actions.tt
@@ -70,16 +70,14 @@
     });
   END;
 
-  IF viewtype == "table" AND count AND layout_obj.user_can("purge");
+  IF viewtype == "table" AND layout_obj.user_can("purge");
     bulk_action_groups.0.items.push({
       id     = "",
       class  = "",
       target = url.page _ "/" _ layout_obj.identifier _ "/purge/",
       label  = "Manage deleted " _ layout.record_name_plural
     });
-  END;
-
-  IF viewtype == "table" AND count AND layout_obj.user_can("purge");
+  
     bulk_action_groups.0.items.push({
       id     = "",
       class  = "",


### PR DESCRIPTION
On testing, it was found that download option was missing from the actions menu. This was due to the count parameter no longer being passed in due to a previous fix implementation.