### PR TITLE
Fix for value-lookup component not being able to continue when erroring [B:1807]

### DIFF
--- a/src/frontend/components/form-group/value-lookup/lib/component.js
+++ b/src/frontend/components/form-group/value-lookup/lib/component.js
@@ -61,7 +61,11 @@ class ValueLookupComponent extends Component {
           for (const [name, value] of Object.entries(data.result)) {
             var $f = $('.linkspace-field[data-name-short="'+name+'"]')
             if(!$f || $f.length == 0) continue;
-            setFieldValues($f, value)
+            try {
+              setFieldValues($f, value)
+            } catch (e) {
+              console.error("Error setting field values", e)
+            }
           }
           removeStatusMessage($field)
         }


### PR DESCRIPTION
Should this error, the system will currently halt the script should it error - this is not correct functionality and a try/catch block is used here.

This was introduced due to the changes required for use with the autorecover functionality.