### PR TITLE
Rolled back error causing filter typeaheads not to work as expected [B: 1815]

### DIFF
--- a/src/frontend/components/form-group/filter/lib/component.js
+++ b/src/frontend/components/form-group/filter/lib/component.js
@@ -218,6 +218,8 @@ class FilterComponent extends Component {
     operators: this.buildFilterOperators(col.type),
     ...(col.type === 'rag'
       ? this.ragProperties
+      : col.hasFilterTypeahead
+      ? this.typeaheadProperties
       : {})
   })
 }
@@ -236,6 +238,28 @@ class FilterComponent extends Component {
     ]
     type === 'daterange' && operators.push('contain')
     return operators
+  }
+
+  get typeaheadProperties() {
+    return {
+      input: (container, input_name) => {
+        return (
+          `<div class='tt__container'>
+            <input class='form-control typeahead_text' type='text' name='${input_name}_text'/>
+            <input class='form-control typeahead_hidden' type='hidden' name='${input_name}'/>
+          </div>`
+        )
+      },
+      valueSetter: (rule, value) => {
+        rule.$el.find('.typeahead_hidden').val(value)
+        const typeahead = rule.$el.find('.typeahead_text')
+        typeahead.typeahead('val',rule.data.text)
+        typeahead.val(rule.data.text)
+      },
+      validation: {
+        callback: () => {return true}
+      }
+    }
   }
 
   getRecords = (layoutId, urlSuffix, instanceId, query) => {


### PR DESCRIPTION
Filter typeaheads were returning an error when trying to save views using them on curvals - this error was caused by #521

In testing, the above caused issues when using short names for filtering on curvals. This issue has been resolved another way.