### PR TITLE
Re-enable Add button on submit error [B: 1805]

### DIFF
--- a/src/frontend/components/button/lib/submit-record-button.ts
+++ b/src/frontend/components/button/lib/submit-record-button.ts
@@ -55,4 +55,8 @@ export default class SubmitRecordButton {
             this.disableButton && $button.prop("disabled", this.requiredHiddenRecordDependentFieldsCleared);
         });
     }
+    public setDisabled(isDisabled: boolean) {
+        this.disableButton = isDisabled;
+        this.el.prop("disabled", isDisabled);
+    }
 }

--- a/src/frontend/components/modal/modals/curval/lib/component.js
+++ b/src/frontend/components/modal/modals/curval/lib/component.js
@@ -6,6 +6,7 @@ import { initializeRegisteredComponents } from 'component'
 import { validateRadioGroup, validateCheckboxGroup } from 'validation'
 import { fromJson } from 'util/common'
 import StorageProvider from 'util/storageProvider'
+import SubmitRecordButton from '../../../../../components/button/lib/submit-record-button.ts'
 
 class CurvalModalComponent extends ModalComponent {
 
@@ -267,7 +268,9 @@ class CurvalModalComponent extends ModalComponent {
       .parents(".modal-content")
       .get(0)
       .scrollIntoView()
-    form.find("button[type=submit]").prop("disabled", false)
+    const $submitBtn = form.find('button[type=submit]');
+    const submitBtnObj = new SubmitRecordButton($submitBtn);
+    submitBtnObj.setDisabled(false);
   }
 
   setupModal() {


### PR DESCRIPTION
Added a public setter to enable or disable the submit button.
Then included this in the modal submit error to unset the Disabled status of the button.