### PR TITLE
Fix views made with whitespace-only names (D1060)

### DIFF
--- a/lib/GADS/View.pm
+++ b/lib/GADS/View.pm
@@ -340,7 +340,7 @@ sub write
 
     # Names consisting of just whitespace characters cause issues when displaying a view
     $self->name !~ /^\s*$/
-        or error __"View name must not contain whitespace characters";
+        or error __"View name must not contain only whitespace characters";
         
     my $global   = !$self->layout->user ? 1 : $self->global;
 

--- a/lib/GADS/View.pm
+++ b/lib/GADS/View.pm
@@ -338,6 +338,10 @@ sub write
     length $self->name < 128
         or error __"View name must be less than 128 characters";
 
+    # Names consisting of just whitespace characters cause issues when displaying a view
+    $self->name !~ /^\s*$/
+        or error __"View name must not contain whitespace characters";
+        
     my $global   = !$self->layout->user ? 1 : $self->global;
 
     $self->clear_writable; # Force rebuild based on any updated values


### PR DESCRIPTION
A regex statement checks if the view name consists of just whitespace characters.
If true, it throws an error to the user.