### PR TITLE
Added appropriate error for blank field name heading in record imports (D1099)

### DIFF
--- a/lib/GADS/Import.pm
+++ b/lib/GADS/Import.pm
@@ -301,7 +301,7 @@ sub _build_fields
             $search->{name_short} = $field if $self->short_names;
             my $f_rs = $self->schema->resultset('Layout')->search($search);
             error __x"Empty field name in import headings (Column {column})", column => $col_count
-                if !$field;
+                unless $field =~ /^\s*$/;
             error __x"Layout has more than one field named {name}", name => $field
                 if $f_rs->count > 1;
             error __x"Field '{name}' in import headings not found in table", name => $field

--- a/lib/GADS/Import.pm
+++ b/lib/GADS/Import.pm
@@ -301,7 +301,7 @@ sub _build_fields
             $search->{name_short} = $field if $self->short_names;
             my $f_rs = $self->schema->resultset('Layout')->search($search);
             error __x"Empty field name in import headings (Column {column})", column => $col_count
-                unless $field =~ /^\s*$/;
+                if $field =~ /^\s*$/;
             error __x"Layout has more than one field named {name}", name => $field
                 if $f_rs->count > 1;
             error __x"Field '{name}' in import headings not found in table", name => $field

--- a/lib/GADS/Import.pm
+++ b/lib/GADS/Import.pm
@@ -267,8 +267,10 @@ sub _build_fields
     my @fields;
     my $column_id = $self->layout->column_id;
 
+    my $col_count     = 0;
     foreach my $field (@$fields_in)
     {
+        $col_count++;
         if (
             (
                 ($self->update_unique && $self->update_unique == $column_id->id) ||
@@ -298,6 +300,8 @@ sub _build_fields
             $search->{name} = $field if !$self->short_names;
             $search->{name_short} = $field if $self->short_names;
             my $f_rs = $self->schema->resultset('Layout')->search($search);
+            error __x"Empty field name in import headings (Column {column})", column => $col_count
+                if !$field;
             error __x"Layout has more than one field named {name}", name => $field
                 if $f_rs->count > 1;
             error __x"Field '{name}' in import headings not found in table", name => $field

--- a/lib/GADS/Import.pm
+++ b/lib/GADS/Import.pm
@@ -267,7 +267,7 @@ sub _build_fields
     my @fields;
     my $column_id = $self->layout->column_id;
 
-    my $col_count     = 0;
+    my $col_count = 0;
     foreach my $field (@$fields_in)
     {
         $col_count++;

--- a/t/014_import.t
+++ b/t/014_import.t
@@ -106,6 +106,13 @@ my @tests = (
         count_off => 1,
     },
     {
+        data      => "string1, ,integer1\nFoo,Bar,123",
+        option    => undef,
+        error     => qr\Empty field name\,
+        count_on  => 1,
+        count_off => 1,
+    },
+    {
         data      => "string1\nString content",
         option    => 'dry_run',
         count_on  => 0,
@@ -228,7 +235,14 @@ foreach my $test (@tests)
 
         my $test_name = defined $test->{option} ? "with option $test->{option} set to $status" : "with no options";
         is($records->count, 0, "No records before import for test $test_name");
-        $import->process;
+        
+        try { $import->process; };
+        if ($test->{error}) 
+        {
+            like($@, $test->{error}, "Got expected import error");
+            next;
+        }
+
         $records->clear;
         is($records->count, $test->{"count_$status"}, "Correct record count on import for test $test_name");
 


### PR DESCRIPTION
Throw an error to the user if a field name heading is blank, alongside the column number in the CSV file being imported.