### PR TITLE
Update cache to ignore values over 250 characters (D1118)

### DIFF
--- a/lib/GADS/Datum/Code.pm
+++ b/lib/GADS/Datum/Code.pm
@@ -162,6 +162,8 @@ sub write_cache
     my $formatter = $self->schema->storage->datetime_parser;
 
     my @values = sort @{$self->value} if defined $self->value->[0];
+    # If the length is greater than 250 characters do not insert it to the cache table
+    return if grep { $_ > 250 } map { length($_) } @values;
 
     # We are generally already in a transaction at this point, but
     # start another one just in case

--- a/lib/GADS/Datum/Code.pm
+++ b/lib/GADS/Datum/Code.pm
@@ -122,6 +122,8 @@ sub _write_unique
     my $schema = $self->schema;
     if (my $table = $self->column->table_unique)
     {
+        # Return and don't write the cache if the value is over 250 characters
+        return if (grep { length($_) > 250 } values %values);
         $schema->storage->svp_begin("sp_uq_calc");
         try {
             $schema->resultset($table)->create({
@@ -162,8 +164,6 @@ sub write_cache
     my $formatter = $self->schema->storage->datetime_parser;
 
     my @values = sort @{$self->value} if defined $self->value->[0];
-    # If the length is greater than 250 characters do not insert it to the cache table
-    return if grep { $_ > 250 } map { length($_) } @values;
 
     # We are generally already in a transaction at this point, but
     # start another one just in case

--- a/t/007_code_cache.t
+++ b/t/007_code_cache.t
@@ -195,17 +195,28 @@ is_deeply([map $_->value_int, $urs->all], $expected, "Correct values for cached 
 
     $record->find_current_id(2);
 
+    $urs = $schema->resultset('CalcUnique')->search({ layout_id => $calc1->id });
+
+    $record->fields->{$string1->id}->set_value("Sandwiches");
+    $record->write(no_alerts => 1);
+
+    my $has_cache = grep {$_ eq "Sandwiches"} map { $_->value_text } $urs->all;
+
+    ok($has_cache, "Value in cache");
+
     $record->fields->{$string1->id}->set_value($long_string);
     $record->write(no_alerts => 1);
 
     is $record->fields->{$string1->id}->as_string, $long_string, "String value set correctly on long string input";
     is $record->fields->{$calc1->id}->as_string, $long_string, "Calc value set correctly on long string input";
 
-    # For some reason, this is not removing (all of) the old cached values - this shows the values as `Bar8` still being there
-    # diag "Cached values: " . join(", ", map { $_->value_text } $urs->all);
+    # Check for the old value in the cache, as it should be removed when the new value is added,
+    # even if the new value is not added to the cache due to length
+    $has_cache = grep {$_ eq "Sandwiches"} map { $_->value_text } $urs->all;
+    ok(!$has_cache, "Old value not in cache");
 
-    my $has_cache = grep {$_ eq $long_string} map { $_->value_text } $urs->all;
-
+    # Check for the new value in the cache, as it should not be added to the cache due to length
+    $has_cache = grep {$_ eq $long_string} map { $_->value_text } $urs->all;
     ok(!$has_cache, "Value not in cache");
 }
 

--- a/t/007_code_cache.t
+++ b/t/007_code_cache.t
@@ -181,6 +181,9 @@ is_deeply([map $_->value_int, $urs->all], $expected, "Correct values for cached 
     is_deeply([map $_->value_text, $urs->all], $expected, "Correct values for cached table after change to int");
 }
 
+# Test input of long string values which exceed the length limit for caching.
+# This test checks that the long value is set correctly on the record, and that the cache is updated to remove the
+# old value and not add the new value due to length
 {
     my $long_string = "Y3EucBXt2aTYnHNb2hXJTrgAg0QqRieA1kxNo1ud2TbcyxrXMXqu".
         "/m83YtthBWYXiEdocydX69XqB/6IK+6NqGDZJgofxgjVxGJmP1HONBT651Yj/".

--- a/t/007_code_cache.t
+++ b/t/007_code_cache.t
@@ -201,6 +201,9 @@ is_deeply([map $_->value_int, $urs->all], $expected, "Correct values for cached 
     is $record->fields->{$string1->id}->as_string, $long_string, "String value set correctly on long string input";
     is $record->fields->{$calc1->id}->as_string, $long_string, "Calc value set correctly on long string input";
 
+    # For some reason, this is not removing (all of) the old cached values - this shows the values as `Bar8` still being there
+    # diag "Cached values: " . join(", ", map { $_->value_text } $urs->all);
+
     my $has_cache = grep {$_ eq $long_string} map { $_->value_text } $urs->all;
 
     ok(!$has_cache, "Value not in cache");

--- a/t/007_code_cache.t
+++ b/t/007_code_cache.t
@@ -181,4 +181,29 @@ is_deeply([map $_->value_int, $urs->all], $expected, "Correct values for cached 
     is_deeply([map $_->value_text, $urs->all], $expected, "Correct values for cached table after change to int");
 }
 
+{
+    my $long_string = "Y3EucBXt2aTYnHNb2hXJTrgAg0QqRieA1kxNo1ud2TbcyxrXMXqu".
+        "/m83YtthBWYXiEdocydX69XqB/6IK+6NqGDZJgofxgjVxGJmP1HONBT651Yj/".
+        "47mRf4+coC3gqvzh6vQ1nCeZyWeVKVuoiiG5INOuwanGJESPDgJrvichI00Czskjah5Ju6/".
+        "tHOez+6p3hciNXUYuq76g6KFkTn4tbWegJd2Hh/bNVYqTX5yDW0MIQQQSoe2i+NLA5xi";
+
+    $record->clear;
+
+    $calc1->code("function evaluate (L1string1) \n return L1string1 \n end");
+    $calc1->return_type('string');
+    $calc1->write;
+
+    $record->find_current_id(2);
+
+    $record->fields->{$string1->id}->set_value($long_string);
+    $record->write(no_alerts => 1);
+
+    is $record->fields->{$string1->id}->as_string, $long_string, "String value set correctly on long string input";
+    is $record->fields->{$calc1->id}->as_string, $long_string, "Calc value set correctly on long string input";
+
+    my $has_cache = grep {$_ eq $long_string} map { $_->value_text } $urs->all;
+
+    ok(!$has_cache, "Value not in cache");
+}
+
 done_testing();

--- a/t/007_code_cache_search.t
+++ b/t/007_code_cache_search.t
@@ -1,0 +1,138 @@
+use Test::More;    # tests => 1;
+use strict;
+use warnings;
+
+use Log::Report;
+use GADS::Layout;
+use GADS::Record;
+use GADS::Records;
+use GADS::Schema;
+use GADS::Filter;
+use GADS::View;
+
+use lib 't/lib';
+use Test::GADS::DataSheet;
+
+use Data::Dump qw(pp);
+
+my $long_string = "Y3EucBXt2aTYnHNb2hXJTrgAg0QqRieA1kxNo1ud2TbcyxrXMXqu"
+                . "/m83YtthBWYXiEdocydX69XqB/6IK+6NqGDZJgofxgjVxGJmP1HONBT651Yj/"
+                . "47mRf4+coC3gqvzh6vQ1nCeZyWeVKVuoiiG5INOuwanGJESPDgJrvichI00Czskjah5Ju6/"
+                . "tHOez+6p3hciNXUYuq76g6KFkTn4tbWegJd2Hh/bNVYqTX5yDW0MIQQQSoe2i+NLA5xi";
+
+my $data = [
+    {
+        string1 => [$long_string],
+    },
+    {
+        string1 => ['The quick brown fox jumps over the lazy dog.'],
+    }
+];
+
+my $sheet = Test::GADS::DataSheet->new(
+    data       => $data,
+    multivalue => 0,
+    calc_code  => "
+            function evaluate (L1string1)
+                return L1string1
+            end
+        ",
+    calc_return_type => 'string',
+);
+$sheet->create_records;
+
+my $schema  = $sheet->schema;
+my $layout  = $sheet->layout;
+my $columns = $sheet->columns;
+my $user    = $sheet->user_normal1;
+
+my $string1 = $columns->{string1};
+my $calc1   = $columns->{calc1};
+
+my $record = GADS::Record->new(
+    layout      => $layout,
+    schema      => $schema,
+    instance_id => 1,
+    user        => $user,
+);
+
+$record->find_current_id(1);
+
+my $filter = GADS::Filter->new(
+    as_hash => {
+        rules => [
+            {
+                id       => $calc1->id,
+                type     => 'string',
+                value    => $long_string,
+                operator => 'equal',
+            }
+        ],
+    },
+);
+
+my $view = GADS::View->new(
+    name        => 'View table',
+    filter      => $filter,
+    instance_id => 1,
+    layout      => $layout,
+    schema      => $schema,
+    is_shared   => 1,
+);
+
+$view->write( no_errors => 1 );
+
+my $records = GADS::Records->new(
+    user   => $user,
+    layout => $layout,
+    schema => $schema,
+    view   => $view
+);
+
+is $records->count, 1, "One record found with long string in calc field";
+
+$filter->as_hash->{rules}[0]{value} = "brown";
+$filter->as_hash->{rules}[0]{operator} = "contains";
+
+my $view2 = GADS::View->new(
+    name        => 'View table 2',
+    filter      => $filter,
+    instance_id => 1,
+    layout      => $layout,
+    schema      => $schema,
+    is_shared   => 1,
+);
+
+$view2->write( no_errors => 1 );
+
+$records->clear;
+
+$records->view($view2);
+
+is $records->count, 1, "One record found with the word `brown` in the string field";
+
+$records->clear;
+
+$records->view(undef);
+
+is $records->count, 2, "No filter, two records found";
+
+$records->clear;
+
+$filter->as_hash->{rules}[0]{value} = "non-existing string";
+$filter->as_hash->{rules}[0]{operator} = "equal";
+
+my $view3 = GADS::View->new(
+    name        => 'View table 3',
+    filter      => $filter,
+    instance_id => 1,
+    layout      => $layout,
+    schema      => $schema,
+    is_shared   => 1,
+);
+
+$records->view($view);
+
+is $records->count, 0, "No records found with non-existing string";
+
+done_testing;

--- a/t/007_code_cache_search.t
+++ b/t/007_code_cache_search.t
@@ -13,8 +13,6 @@ use GADS::View;
 use lib 't/lib';
 use Test::GADS::DataSheet;
 
-use Data::Dump qw(pp);
-
 my $long_string = "Y3EucBXt2aTYnHNb2hXJTrgAg0QqRieA1kxNo1ud2TbcyxrXMXqu"
                 . "/m83YtthBWYXiEdocydX69XqB/6IK+6NqGDZJgofxgjVxGJmP1HONBT651Yj/"
                 . "47mRf4+coC3gqvzh6vQ1nCeZyWeVKVuoiiG5INOuwanGJESPDgJrvichI00Czskjah5Ju6/"


### PR DESCRIPTION
This code checks the `%values` hash and does not insert the value into the cache should there be any values over 250 characters inserted into the field.