### PR TITLE
Upgraded Password Validation/Rehashing in API.pm (D805)

### DIFF
--- a/lib/GADS.pm
+++ b/lib/GADS.pm
@@ -86,7 +86,7 @@ use WWW::Mechanize::Chrome;
 use Dancer2; # Last to stop Moo generating conflicting namespace
 use Dancer2::Plugin::DBIC;
 use Dancer2::Plugin::Auth::Extensible;
-use Dancer2::Plugin::Auth::Extensible::Provider::DBIC 0.623;
+use Dancer2::Plugin::Auth::Extensible::Provider::DBIC 0.625;
 use Dancer2::Plugin::LogReport 'linkspace';
 
 use GADS::API; # API routes

--- a/lib/GADS.pm
+++ b/lib/GADS.pm
@@ -86,7 +86,7 @@ use WWW::Mechanize::Chrome;
 use Dancer2; # Last to stop Moo generating conflicting namespace
 use Dancer2::Plugin::DBIC;
 use Dancer2::Plugin::Auth::Extensible;
-use Dancer2::Plugin::Auth::Extensible::Provider::DBIC 0.625;
+use Dancer2::Plugin::Auth::Extensible::Provider::DBIC;
 use Dancer2::Plugin::LogReport 'linkspace';
 
 use GADS::API; # API routes

--- a/lib/GADS/API.pm
+++ b/lib/GADS/API.pm
@@ -28,6 +28,7 @@ use URI::Escape qw/uri_escape_utf8/;
 
 use Dancer2 appname => 'GADS';
 use Dancer2::Plugin::Auth::Extensible;
+use Dancer2::Plugin::CryptPassphrase;
 use Dancer2::Plugin::DBIC;
 use Dancer2::Plugin::LogReport 'linkspace';
 
@@ -56,8 +57,19 @@ my $verify_user_password_sub = sub {
         username => $args{username},
     })->next;
 
-    $user && Crypt::SaltedHash->validate($user->password, $args{password})
-        and return ($client->id, undef, undef, $user->id);
+    if ($user) {
+        my $stored = $user->password;
+
+        if (crypt_passphrase->verify_password($args{password}, $stored)) {
+            return ($client->id, undef, undef, $user->id);
+        }
+        if (Crypt::SaltedHash->validate($stored, $args{password})) {
+            my $new_hash = crypt_passphrase->hash_password($args{password});
+            $user->update({ password => $new_hash });
+
+            return ($client->id, undef, undef, $user->id);
+        }
+    }
 
     return (0, 'access_denied');
 };

--- a/lib/GADS/API.pm
+++ b/lib/GADS/API.pm
@@ -60,18 +60,17 @@ my $verify_user_password_sub = sub {
     if ($user) {
         my $stored = $user->password;
 
-        if (crypt_passphrase->verify_password($args{password}, $stored)) {
-            return ($client->id, undef, undef, $user->id);
+        if (!crypt_passphrase->verify_password($args{password}, $stored)) {
+            return (0, 'access_denied');
         }
-        if (Crypt::SaltedHash->validate($stored, $args{password})) {
+        if (crypt_passphrase->needs_rehash($stored)) {
             my $new_hash = crypt_passphrase->hash_password($args{password});
             $user->update({ password => $new_hash });
 
-            return ($client->id, undef, undef, $user->id);
         }
     }
-
-    return (0, 'access_denied');
+    
+    return ($client->id, undef, undef, $user->id);
 };
 
 my $store_access_token_sub = sub {


### PR DESCRIPTION
API.pm password handling has been upgraded to use Crypt::Passphrase for validation and rehashing. The use of Crypt::SaltedHash remains, however all hashes encoded with this library is rehashed by Crypt::Passphrase upon validation.