### PR TITLE
Fix display condition bug (D797)

### DIFF
--- a/src/frontend/components/button/lib/submit-field-button.ts
+++ b/src/frontend/components/button/lib/submit-field-button.ts
@@ -9,6 +9,8 @@ declare global {
                 treeApi: string;
             }
         }
+        // Fix the undefined function while we're here
+        UpdateFilter?: (filterEl:JQuery<HTMLElement>, ev:JQuery.ClickEvent) => void;
     }
     interface JQuery<TElement = HTMLElement> {
         queryBuilder(operation: string): JQuery<TElement>;
@@ -34,7 +36,7 @@ export default class SubmitFieldButton {
 
             const $displayConditionsBuilderEl = $('#displayConditionsBuilder');
             //Bit of typecasting here, purely because the queryBuilder plugin doesn't have types
-            const res = $displayConditionsBuilderEl.length && $displayConditionsBuilderEl.queryBuilder('getRules');
+            const res = $displayConditionsBuilderEl.length && $displayConditionsBuilderEl.queryBuilder('getRules', {allow_invalid: true});
             const peopleConditionsFieldEl = $('.people-filter');
             const $peopleConditionsFieldRes = peopleConditionsFieldEl.length && $('#field_type').val() == 'person' && peopleConditionsFieldEl.queryBuilder('getRules');
             const $displayConditionsField = $('#displayConditions');
@@ -95,9 +97,7 @@ export default class SubmitFieldButton {
                 });
             }
 
-            // @ts-expect-error - This is a global function
             if (bUpdateFilter && window.UpdateFilter) {
-                // @ts-expect-error - This is a global function
                 window.UpdateFilter($filterEl, ev);
             }
 
@@ -105,8 +105,27 @@ export default class SubmitFieldButton {
                 window.UpdatePeopleFilter(peopleConditionsFieldEl, ev);
             }
 
-            if (bUpdateDisplayConditions) {
+            if (bUpdateDisplayConditions && res && res.valid) {
                 $displayConditionsField.val(JSON.stringify(res, null, 2));
+            } else if (res) {
+                /*
+                 * This is to fix and mitigate empty rules - for some reason this is behaving differently and a regressive bug has been
+                 * re-introduced where empty rules are being allowed, and this causes the display conditions to be lost.
+                 * I would try to find the original cause, but I think this is actually a "better" solution as it fixes the issue
+                 * and allows for better handling of invalid rules, thereby removing the possibility of losing data.
+                 */
+                const {rules} = res;
+                console.log("Original rules:", rules);
+                const fixedRules = rules.filter((rule) => !Object.values(rule).some((value) => !value));
+                console.log("Fixed rules:", fixedRules);
+                res.rules = fixedRules;
+                $displayConditionsBuilderEl.queryBuilder('setRules', res);
+                if(!$displayConditionsBuilderEl.queryBuilder('validate')) {
+                    alert("The display conditions are invalid. Please fix them before submitting the form.");
+                    ev.preventDefault();
+                } else {
+                    $displayConditionsField.val(JSON.stringify(res, null, 2));
+                }
             }
 
             /* By default, if the permissions datatable is paginated, then the

--- a/src/frontend/components/button/lib/submit-field-button.ts
+++ b/src/frontend/components/button/lib/submit-field-button.ts
@@ -11,8 +11,6 @@ declare global {
                 treeApi: string;
             }
         }
-        // Fix the undefined function while we're here
-        UpdateFilter?: (filterEl:JQuery<HTMLElement>, ev:JQuery.ClickEvent) => void;
     }
     interface JQuery<TElement = HTMLElement> {
         queryBuilder(operation: string): JQuery<TElement>;
@@ -102,7 +100,9 @@ export default class SubmitFieldButton {
                 });
             }
 
+            // @ts-expect-error - This is a global function
             if (bUpdateFilter && window.UpdateFilter) {
+                // @ts-expect-error - This is a global function
                 window.UpdateFilter($filterEl, ev);
             }
 

--- a/src/frontend/components/button/lib/submit-field-button.ts
+++ b/src/frontend/components/button/lib/submit-field-button.ts
@@ -1,6 +1,8 @@
+/* eslint-disable */
 import "jstree";
 import "datatables.net";
 import "@lol768/jquery-querybuilder-no-eval"
+import { validateQueryBuilder } from "validation";
 
 declare global {
     interface Window {
@@ -29,6 +31,7 @@ export default class SubmitFieldButton {
      */
     constructor(element:JQuery<HTMLElement>) {
         element.on('click', (ev) => {
+            const $form = $(ev.currentTarget).closest('form') as JQuery<HTMLFormElement>;
 
             const $jstreeContainer = $('#field_type_tree');
             const $jstreeEl = $('#tree-config .tree-widget-container');
@@ -36,7 +39,7 @@ export default class SubmitFieldButton {
 
             const $displayConditionsBuilderEl = $('#displayConditionsBuilder');
             //Bit of typecasting here, purely because the queryBuilder plugin doesn't have types
-            const res = $displayConditionsBuilderEl.length && $displayConditionsBuilderEl.queryBuilder('getRules', {allow_invalid: true});
+            const res = $displayConditionsBuilderEl.length && $displayConditionsBuilderEl.queryBuilder('getRules');
             const peopleConditionsFieldEl = $('.people-filter');
             const $peopleConditionsFieldRes = peopleConditionsFieldEl.length && $('#field_type').val() == 'person' && peopleConditionsFieldEl.queryBuilder('getRules');
             const $displayConditionsField = $('#displayConditions');
@@ -72,7 +75,9 @@ export default class SubmitFieldButton {
                 bUpdateFilter = true;
             }
 
-            if (res && $displayConditionsField.length) {
+            if(!validateQueryBuilder($displayConditionsBuilderEl)) {
+                ev.preventDefault();
+            } else if (res && $displayConditionsField.length) {
                 bUpdateDisplayConditions = true;
             }
 
@@ -105,27 +110,8 @@ export default class SubmitFieldButton {
                 window.UpdatePeopleFilter(peopleConditionsFieldEl, ev);
             }
 
-            if (bUpdateDisplayConditions && res && res.valid) {
+            if (bUpdateDisplayConditions && res) {
                 $displayConditionsField.val(JSON.stringify(res, null, 2));
-            } else if (res) {
-                /*
-                 * This is to fix and mitigate empty rules - for some reason this is behaving differently and a regressive bug has been
-                 * re-introduced where empty rules are being allowed, and this causes the display conditions to be lost.
-                 * I would try to find the original cause, but I think this is actually a "better" solution as it fixes the issue
-                 * and allows for better handling of invalid rules, thereby removing the possibility of losing data.
-                 */
-                const {rules} = res;
-                console.log("Original rules:", rules);
-                const fixedRules = rules.filter((rule) => !Object.values(rule).some((value) => !value));
-                console.log("Fixed rules:", fixedRules);
-                res.rules = fixedRules;
-                $displayConditionsBuilderEl.queryBuilder('setRules', res);
-                if(!$displayConditionsBuilderEl.queryBuilder('validate')) {
-                    alert("The display conditions are invalid. Please fix them before submitting the form.");
-                    ev.preventDefault();
-                } else {
-                    $displayConditionsField.val(JSON.stringify(res, null, 2));
-                }
             }
 
             /* By default, if the permissions datatable is paginated, then the
@@ -134,7 +120,6 @@ export default class SubmitFieldButton {
              * and appends them to the form manually */
             const $inputs = $permissionTable.DataTable().$('input,select,textarea');
             $inputs.hide(); // Stop them appearing to the user in a strange format
-            const $form = $(ev.currentTarget).closest('form');
             $permissionTable.remove();
             $form.append($inputs);
         });

--- a/src/frontend/components/form-group/display-conditions/lib/component.js
+++ b/src/frontend/components/form-group/display-conditions/lib/component.js
@@ -25,13 +25,11 @@ class DisplayConditionsComponent extends Component {
         { type: 'contains', accept_values: true, apply_to: ['string'] },
         { type: 'not_equal', accept_values: true, apply_to: ['string'] },
         { type: 'not_contains', accept_values: true, apply_to: ['string'] }
-      ]
-    })
-
-    if (builderData.filterBase) {
-      const data = JSON.parse(atob(builderData.filterBase))
-      this.el.queryBuilder('setRules', data)
-    }
+      ],
+      allow_empty: true
+    }).queryBuilder('setRules', builderData.filterBase 
+      ? JSON.parse(atob(builderData.filterBase)) 
+      : {rules:[]});
   }
 }
 

--- a/src/frontend/js/lib/validation.js
+++ b/src/frontend/js/lib/validation.js
@@ -1,3 +1,5 @@
+import { DangerAlert } from "components/alert/lib/dangerAlert";
+
 // Bind events to a field to trigger validation
 const initValidationOnField = (field) => {
   // Input
@@ -299,6 +301,20 @@ const validateTree = (field) => {
   }
 }
 
+const validateQueryBuilder = (field) => {
+  if(!(field && field.length)) return;
+  const result = field.queryBuilder('validate');
+  if(!result) {
+    if($('.display-conditions-error').length) return false;
+    const danger = new DangerAlert('There are errors in the conditions you have set, please fix these before submitting the form');
+    const banner = danger.render();
+    banner.classList.add('mb-3', 'mt-0', 'display-conditions-error');
+    field.closest('.card__content').prepend(banner);
+    return false;
+  }
+  return true;
+}
+
 // Expand the card with a certain field and scroll it into view
 const expandCardValidate = (field) => {
   const $collapse = $(field).closest('.card--expandable').find('.collapse')
@@ -321,4 +337,4 @@ const expandCardValidate = (field) => {
   }
 }
 
-export { initValidationOnField, validateTree, validateRadioGroup, validateCheckboxGroup, validateRequiredFields };
+export { initValidationOnField, validateTree, validateRadioGroup, validateCheckboxGroup, validateRequiredFields, validateQueryBuilder };


### PR DESCRIPTION
This is to fix a regressive bug that was introduced into this version.

The bug caused the following to occur:
* A new, empty display condition was added to display conditions when editing fields
* Any invalid or empty display conditions caused *all* display conditions to clear from the field

The fix also contains better mitigation and handling for the display condition builder and filters out invalid rules on save.