### PR TITLE
Trixie unit tests (maintenance)

### DIFF
--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -1,21 +1,23 @@
 #!/bin/bash
 
+set -e
+
 apt-get update
 apt-get install -y curl gpg
 curl -o- https://debian.ctrlo.com/repos/apt/debian/whatever.gpg.key | gpg --dearmor -o /usr/share/keyrings/ctrlo-keyring.gpg
-echo 'deb [signed-by=/usr/share/keyrings/ctrlo-keyring.gpg] https://debian.ctrlo.com/repos/apt/debian/ bookworm main' | tee /etc/apt/sources.list.d/ctrlo.list
+echo 'deb [signed-by=/usr/share/keyrings/ctrlo-keyring.gpg] https://debian.ctrlo.com/repos/apt/debian/ trixie main' | tee /etc/apt/sources.list.d/ctrlo.list
+
 apt-get update
-apt-get install -y libapache2-mod-fastcgi libapache2-mod-perl2 libconfig-inifiles-perl libcrypt-saltedhash-perl libcrypt-urandom-perl libdancer2-perl
-apt-get install -y libdancer2-plugin-auth-extensible-provider-dbic-perl libdancer2-plugin-dbic-perl libdancer2-session-dbic-perl
-apt-get install -y libdata-dump-streamer-perl libdata-visitor-perl libdatetime-format-mysql-perl libdbd-mysql-perl libdbix-class-migration-perl
-apt-get install -y libdbix-class-perl libfcgi-perl libfile-copy-recursive-perl libio-all-perl liblog-report-lexicon-perl liblog-report-perl
-apt-get install -y libmail-box-perl libmail-transport-perl libmath-random-isaac-xs-perl libmoox-singleton-perl libpod-parser-perl libregexp-common-perl
-apt-get install -y libstring-camelcase-perl libtemplate-perl libtext-autoformat-perl libtext-csv-perl libyaml-libyaml-perl libdatetime-format-cldr-perl
-apt-get install -y libtree-dagnode-perl libalgorithm-dependency-perl libdatetime-set-perl libdata-compare-perl libdatetime-event-random-perl
-apt-get install -y libtext-csv-encoded-perl libhtml-fromtext-perl libhtml-scrubber-perl libdbd-pg-perl postgresql postgresql-contrib
-apt-get install -y libdatetime-format-pg-perl libset-infinite-perl libtie-cache-perl libdbix-class-helpers-perl libmath-round-perl
-apt-get install -y libmoox-types-mooselike-datetime-perl libdatetime-format-datemanip-perl libinline-lua-perl lua5.2 libctrlo-crypt-xkcdpassword-perl
-apt-get install -y libfile-slurp-perl libfile-mimeinfo-perl liblist-compare-perl libnet-oauth2-authorizationserver-perl libfontconfig1
-apt-get install -y libctrlo-pdf-perl libpdf-builder-perl fonts-liberation libdate-holidays-gb-perl libcgi-deurl-xs-perl libfile-bom-perl
-apt-get install -y libdatetime-format-iso8601-perl liblog-log4perl-perl libwww-mechanize-chrome-perl chromium libfile-libmagic-perl libnet-saml2-perl
-apt-get install -y liburl-encode-perl libtext-markdown-perl libtest-tempdir-tiny-perl libtest-mocktime-perl
+# dependencies as found when trying to run the tests in a clean docker container
+apt-get install -y libctrlo-crypt-xkcdpassword-perl libdatetime-perl libdancer2-plugin-logreport-perl libmoox-types-mooselike-perl \
+                   libhtml-fromtext-perl libdatetime-format-cldr-perl libpath-class-perl libmoox-singleton-perl libalgorithm-dependency-perl \
+                   libstring-camelcase-perl libdata-compare-perl libdbix-class-perl libctrlo-pdf-perl libsession-token-perl libhtml-scrubber-perl \
+                   libtext-markdown-perl libmail-message-perl liblingua-en-inflect-perl libmail-transport-perl libdatetime-format-iso8601-perl \
+                   libdbix-class-helpers-perl libfile-bom-perl libtext-csv-perl libmoox-types-mooselike-datetime-perl liblist-compare-perl \
+                   libmath-round-perl libtext-csv-encoded-perl libcgi-deurl-xs-perl libtree-dagnode-perl libdatetime-format-datemanip-perl \
+                   libdate-holidays-gb-perl libinline-lua-perl libfile-libmagic-perl libnet-saml2-perl liburl-encode-perl \
+                   libmath-random-isaac-xs-perl libtie-cache-perl libwww-mechanize-chrome-perl libdancer2-plugin-dbic-perl \
+                   libdancer2-plugin-auth-extensible-perl libdancer2-plugin-auth-extensible-provider-dbic-perl \
+                   libnet-oauth2-authorizationserver-perl libdbd-pg-perl
+# test dependencies
+apt-get install -y libtest-mocktime-perl libtest-tempdir-tiny-perl libdbd-sqlite3-perl libdatetime-format-sqlite-perl

--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -8,16 +8,23 @@ curl -o- https://debian.ctrlo.com/repos/apt/debian/whatever.gpg.key | gpg --dear
 echo 'deb [signed-by=/usr/share/keyrings/ctrlo-keyring.gpg] https://debian.ctrlo.com/repos/apt/debian/ trixie main' | tee /etc/apt/sources.list.d/ctrlo.list
 
 apt-get update
-# dependencies as found when trying to run the tests in a clean docker container
-apt-get install -y libctrlo-crypt-xkcdpassword-perl libdatetime-perl libdancer2-plugin-logreport-perl libmoox-types-mooselike-perl \
-                   libhtml-fromtext-perl libdatetime-format-cldr-perl libpath-class-perl libmoox-singleton-perl libalgorithm-dependency-perl \
-                   libstring-camelcase-perl libdata-compare-perl libdbix-class-perl libctrlo-pdf-perl libsession-token-perl libhtml-scrubber-perl \
-                   libtext-markdown-perl libmail-message-perl liblingua-en-inflect-perl libmail-transport-perl libdatetime-format-iso8601-perl \
-                   libdbix-class-helpers-perl libfile-bom-perl libtext-csv-perl libmoox-types-mooselike-datetime-perl liblist-compare-perl \
-                   libmath-round-perl libtext-csv-encoded-perl libcgi-deurl-xs-perl libtree-dagnode-perl libdatetime-format-datemanip-perl \
-                   libdate-holidays-gb-perl libinline-lua-perl libfile-libmagic-perl libnet-saml2-perl liburl-encode-perl \
-                   libmath-random-isaac-xs-perl libtie-cache-perl libwww-mechanize-chrome-perl libdancer2-plugin-dbic-perl \
-                   libdancer2-plugin-auth-extensible-perl libdancer2-plugin-auth-extensible-provider-dbic-perl \
-                   libnet-oauth2-authorizationserver-perl libdbd-pg-perl
+# Install Dancer2
+apt-get install -y libapache2-mod-fastcgi libapache2-mod-perl2 libauth-yubikey-webclient-perl libauthen-oath-perl libconfig-inifiles-perl \
+                   libconvert-base32-perl libcpanel-json-xs-perl libcrypt-saltedhash-perl libcrypt-urandom-perl libdancer2-perl \
+                   libdancer2-plugin-auth-extensible-provider-dbic-perl libdancer2-plugin-dbic-perl libdancer2-session-dbic-perl \
+                   libdata-dump-streamer-perl libdata-visitor-perl libdatetime-format-mysql-perl libdbd-mysql-perl libdbix-class-helpers-perl \
+                   libdbix-class-migration-perl libdbix-class-perl libfcgi-perl libfile-copy-recursive-perl libimager-qrcode-perl libimager-perl \
+                   libio-all-perl liblog-report-lexicon-perl liblog-report-perl liblog-report-template-perl libdancer2-plugin-logreport-perl \
+                   libmail-box-perl libmail-transport-perl libmath-random-isaac-xs-perl libmoox-singleton-perl libpod-parser-perl \
+                   libregexp-common-perl libstring-camelcase-perl libtemplate-perl libtext-autoformat-perl libtext-csv-perl libyaml-libyaml-perl
+# Install GADS
+apt-get install -y libdatetime-format-cldr-perl libtree-dagnode-perl libalgorithm-dependency-perl libdatetime-set-perl libdata-compare-perl \
+                   libdatetime-event-random-perl libtext-csv-encoded-perl libhtml-fromtext-perl libhtml-scrubber-perl libdbd-pg-perl postgresql \
+                   postgresql-contrib libdatetime-format-pg-perl libset-infinite-perl libtie-cache-perl libmath-round-perl \
+                   libmoox-types-mooselike-datetime-perl libdatetime-format-datemanip-perl libinline-lua-perl lua5.2 libctrlo-crypt-xkcdpassword-perl \
+                   libfile-slurp-perl libfile-mimeinfo-perl liblist-compare-perl libnet-oauth2-authorizationserver-perl libfontconfig1 \
+                   libctrlo-pdf-perl libpdf-builder-perl fonts-liberation libdate-holidays-gb-perl libcgi-deurl-xs-perl libfile-bom-perl \
+                   libdatetime-format-iso8601-perl liblog-log4perl-perl libwww-mechanize-chrome-perl chromium libfile-libmagic-perl \
+                   libnet-saml2-perl liburl-encode-perl libtext-markdown-perl
 # test dependencies
-apt-get install -y libtest-mocktime-perl libtest-tempdir-tiny-perl libdbd-sqlite3-perl libdatetime-format-sqlite-perl
+apt-get install -y libtest-mocktime-perl libtest-tempdir-tiny-perl libdbd-sqlite3-perl libdatetime-format-sqlite-perl libtest-compile-perl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     name: 'Unit Tests'
     runs-on: 'ubuntu-22.04'
     timeout-minutes: 30
-    container: debian:bookworm
+    container: debian:trixie
 
     steps:
       - name: 'Check out the GADS repository'

--- a/t/000_compile.t
+++ b/t/000_compile.t
@@ -1,0 +1,11 @@
+use Test::More;
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use Test::Compile;
+
+my $test = Test::Compile->new;
+$test->ok($test->pl_file_compiles('./lib/GADS.pm'), 'GADS compiles');
+$test->done_testing();


### PR DESCRIPTION
Update and remove dependencies where not needed items were causing unit test set up to take too long, and updated test file to run on debian:trixie container for perl unit tests.